### PR TITLE
update: deprecated な includeCoAuthoredBy を attribution に置換

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -9,7 +9,11 @@ let
     autoMemoryEnabled = false;
     effortLevel = "high";
     env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
-    includeCoAuthoredBy = false;
+    # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr 双方の帰属表示を空文字列化して抑止する。
+    attribution = {
+      commit = "";
+      pr = "";
+    };
     enabledPlugins = {
       "typescript-lsp@claude-plugins-official" = true;
       "pyright-lsp@claude-plugins-official" = true;


### PR DESCRIPTION
## 調査したアップデート

Claude Code の直近リリースノート（v2.1.101 〜 v2.1.113）と settings 公式ドキュメントを確認した。主要な更新は以下。

### Claude Code
- **v2.1.111**: `effortLevel` に `xhigh` 追加（Opus 4.7 専用）、Auto モードが Max サブスクライバー向けに解放、`/ultrareview` 追加。
- **v2.1.113**: CLI がネイティブバイナリ化、`sandbox.network.deniedDomains` 追加。
- **v2.1.108**: `recap`、1 時間プロンプトキャッシング env var (`ENABLE_PROMPT_CACHING_1H`)。
- **v2.1.105**: `PreCompact` フック追加、プラグイン background monitor サポート。
- **v2.1.101**: `cleanupPeriodDays: 0` を `settings.json` validation で拒否する破壊的変更。
- **settings ドキュメント**: `includeCoAuthoredBy` が **deprecated** 化され、`attribution` 設定（`commit` / `pr`）に一元化された旨が明記。
- **autoScrollEnabled / sandbox.* / disableBypassPermissionsMode** などの新キーも追加。

### nix-darwin / home-manager / nixpkgs
- 25.11 が 2025-11 に安定化済み（現状は 25.05）。

### mise / Homebrew 他
- Homebrew 経由のため個別ツールは `brew upgrade` に任せられ、dotfiles 側の宣言的管理と分離済み。

## 優先度判定

| 項目 | 優先度 | 理由 |
| :-- | :-- | :-- |
| **`includeCoAuthoredBy` → `attribution` 移行** | **高** | 公式ドキュメントで deprecated 明言。将来的に動作しなくなるリスクがあり、かつ単純な置換で現挙動を維持可能。 |
| `sandbox.*` 設定導入 | 中 | `defaultMode = "bypassPermissions"` 運用と競合する可能性があり、影響範囲が広く手動検証が必要。 |
| `autoScrollEnabled` 等 UI 設定 | 中 | 機能影響なし、個人の好み次第。 |
| `PreCompact` / `CwdChanged` 等新フック | 低 | `autoCompact = false` 等で現状ユースケースなし。 |
| nixpkgs / nix-darwin / home-manager 25.11 昇格 | 中 | 動作確認を伴うため人手での `make rebuild` 検証推奨。自動 PR の対象外と判断。 |
| `effortLevel = "high"` 見直し | 対象外 | 現値は最新仕様でも有効。 |

→ **「高」と判定したのは `includeCoAuthoredBy` → `attribution` 移行のみ**。本 PR はこれのみを対象とする。

## 変更内容

- `home-manager/programs/claude/default.nix`
  - `includeCoAuthoredBy = false;` を削除
  - `attribution = { commit = ""; pr = ""; };` を追加し、Co-Authored-By / PR 説明の帰属表示抑止という従来の意図を保持

## Test plan

- [ ] `make check` で flake 評価がパスすること
- [ ] `make switch` 後、`cat ~/.config/claude/settings.json` に `attribution` が反映されること
- [ ] Claude Code のコミット生成時に Co-Authored-By / 🤖 Generated with ... が付与されないこと

https://claude.ai/code/session_01BVjvRpDuFowHo2UQMnSNqJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small configuration change that swaps a deprecated setting for its replacement and should only affect commit/PR attribution text generation.
> 
> **Overview**
> Updates Claude Code settings generation to stop using deprecated `includeCoAuthoredBy` and instead sets `attribution.commit` and `attribution.pr` to empty strings to suppress attribution text in generated commits/PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1710faa6decfb3e5cd1db64ed88e471e56dfd90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Claudeの設定を更新し、非推奨のオプションから新しい属性設定形式に変更しました。コミット・プルリクエスト属性の処理方法を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->