### PR TITLE
remove: 無効な autoCompact 設定を削除（Claude Code スキーマ追従）

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -5,7 +5,6 @@ let
     "$schema" = "https://json.schemastore.org/claude-code-settings.json";
     language = "Japanese";
     alwaysThinkingEnabled = true;
-    autoCompact = false;
     autoMemoryEnabled = false;
     effortLevel = "high";
     env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";


### PR DESCRIPTION
## 概要

Claude Code の最新リリースノート（〜v2.1.114）および最新ドキュメントを確認し、`home-manager/programs/claude/default.nix` の `autoCompact = false` を削除した。

## 調査したアップデート内容

### Claude Code changelog（主な項目、v2.1.80〜v2.1.114）
- **v2.1.114**: permission dialog のクラッシュ修正
- **v2.1.113**: `sandbox.network.deniedDomains` 設定追加、Bash deny ルールが `env`/`sudo`/`watch` ラッパーにも適用、ネイティブバイナリ化
- **v2.1.111**: Opus 4.7 `xhigh` effort level、`/less-permission-prompts` / `/ultrareview` skill 追加
- **v2.1.110**: `tui = "fullscreen"` コマンド、`autoScrollEnabled` 追加
- **v2.1.108**: `ENABLE_PROMPT_CACHING_1H`、recap 機能（`awaySummaryEnabled`）
- **v2.1.105**: `PreCompact` フック追加
- **v2.1.101**: OS CA 証明書ストアを既定で信頼
- **v2.1.98**: Linux 向けサブプロセス sandboxing、Monitor ツール
- **v2.1.94**: `keep-coding-instructions` frontmatter、plugin skills の `name` 参照変更
- **v2.1.91**: `disableSkillShellExecution` 設定
- **v2.1.89**: `PermissionDenied` フック、`defer` 権限判定
- **v2.1.83**: `managed-settings.d/`、`CwdChanged` / `FileChanged` / `TaskCreated` / `WorktreeCreate` フック、`sandbox.failIfUnavailable`、`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`
- **v2.1.80**: `effort` frontmatter（skills/slash commands）

### 最新ドキュメント確認
- [settings.json 公式スキーマ](https://json.schemastore.org/claude-code-settings.json) の top-level プロパティに `autoCompact` は**存在しない**
- [公式ドキュメント](https://code.claude.com/docs/en/settings) にも `autoCompact` の記載なし
- コンテキスト圧縮制御は `PreCompact` / `PostCompact` フックまたは `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` 環境変数（`/en/env-vars`）に移行済み
- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` は依然として必須（現状のまま）
- `attribution` 設定は既に適用済み（`includeCoAuthoredBy` deprecated から移行済み）
- 現在のフック（`Stop` / `PermissionRequest` / `PostToolUse`）は全て valid

## 優先度判定

| 項目 | 優先度 | 対応 |
|---|---|---|
| `autoCompact = false` の削除 | **高** | **本 PR で対応** |
| `effortLevel`: `"high"` → `"xhigh"`（Opus 4.7 向け）| 中 | 未対応（嗜好依存）|
| `tui = "fullscreen"` 追加（v2.1.110）| 中 | 未対応（UI 挙動変更）|
| `awaySummaryEnabled` による recap（v2.1.108）| 低 | 未対応 |
| `sandbox.*` 導入 | 低 | 未対応（現状の運用を変える必要なし）|
| 新規フック（`PreCompact` 等）の活用 | 低 | 未対応（具体要件が発生してから）|

### なぜ「高」と判定したか
`autoCompact = false` は：
1. `$schema` 先の公式 JSON Schema に**存在しないキー**で、エディタ上で検証警告が出る
2. Claude Code 本体でも**silent に無視**される既知の挙動（[issue #38483](https://github.com/anthropics/claude-code/issues/38483)）
3. コミット履歴（`e0d0e15`）を見るに「auto-compact を無効化する」意図で追加されたが、その意図が実現していない**機能的な瑕疵**がある
4. 放置すると「設定済み」と誤認し、本来必要な代替手段（`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` など）の導入判断が遅れる

他の項目は新機能の opt-in であり、ユーザー嗜好・運用方針に依存するため中／低に分類した。

## 変更内容

```diff
-    autoCompact = false;
```

## 注意事項

本 PR では `autoCompact = false` を単に削除する。`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` での代替は設定値が運用依存（閾値調整のみでオフにはできない）のため、必要時に別途検討。

## テスト

- [ ] `make switch` で反映して設定が正しく生成されることを確認
- [ ] `~/.config/claude/settings.json` に `autoCompact` が含まれないこと
- [ ] `/status` または `/config` で警告が出ていないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 設定ファイルをシンプル化しました。デフォルト設定の利用により、より効率的な動作が実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->