### PR TITLE
add: showThinkingSummaries を有効化して alwaysThinkingEnabled と挙動を揃える

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -5,6 +5,9 @@ let
     "$schema" = "https://json.schemastore.org/claude-code-settings.json";
     language = "Japanese";
     alwaysThinkingEnabled = true;
+    # alwaysThinkingEnabled = true でも showThinkingSummaries のデフォルトは false のため
+    # インタラクティブセッションでは thinking block が redacted 表示となる。意図と揃える。
+    showThinkingSummaries = true;
     autoMemoryEnabled = false;
     effortLevel = "high";
     env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";


### PR DESCRIPTION
## 背景

Claude Code のリリースノート (CHANGELOG, v2.1.108 〜 v2.1.116 近辺) および最新 `settings.json` ドキュメントを確認し、本 dotfiles に反映すべき差分を棚卸しした。

## 確認したアップデート一覧（抜粋）

### 新規 settings.json オプション
- `showThinkingSummaries` — extended thinking の要約表示制御（デフォルト `false`）
- `autoScrollEnabled` — fullscreen 時の自動スクロール
- `sandbox.network.deniedDomains` / `sandbox.failIfAvailable`
- `disableDeepLinkRegistration` — `claude-cli://` プロトコル登録抑止
- `disableSkillShellExecution` — skill / カスタムコマンド内のシェル実行抑止
- `showClearContextOnPlanAccept`
- `minimumVersion`, `autoUpdatesChannel`

### 新規 Hook イベント
- `CwdChanged`, `FileChanged`, `TaskCreated`, `PostCompact`, `PermissionDenied`
- `Elicitation` / `ElicitationResult` (MCP 構造化入力)

### 廃止・リネーム
- `/tag`, `/vim`, `TaskOutput` ツール: 廃止
- `/fork` → `/branch` (互換性維持)
- `includeCoAuthoredBy` → `attribution` (本リポジトリでは対応済み)

### プラグイン / Skills 拡張
- `extraKnownMarketplaces` に `source: 'settings'` サポート
- skills frontmatter に `effort` / agents frontmatter に `initialPrompt`, `maxTurns`, `disallowedTools`

## 優先度判定

### 高 → 本 PR で対応
- **`showThinkingSummaries = true` を追加**
  - 現状 `alwaysThinkingEnabled = true` を設定済みだが、`showThinkingSummaries` のデフォルトが `false` (interactive mode) のため、thinking block は API 側で redact され、折り畳まれたスタブでしか見えない。
  - 「extended thinking を常時有効にしたい」という現状の意図と、実際にインタラクティブセッションで見える挙動にズレがあるため、意図に揃える修正を高優先度と判断。

### 中 → 本 PR では見送り
- `includeGitInstructions = false` — git-commit / git-pr 等の独自スキルが充実しており、組み込み git instructions は冗長気味。ただし現状で害は無く、スキル側の挙動確認を含めて別 PR で対応したい。
- `autoUpdatesChannel = "stable"` — 安定版追従。現状の latest 追従でも実害はなく、判断は運用ポリシー次第。

### 低 → 見送り
- `sandbox.*` / `disableSkillShellExecution` — 既存スキルの挙動検証が必要で影響範囲が広い。
- `spinnerTipsEnabled` / `showTurnDuration` 等の UX 項目 — 好みレベル。

## 変更内容

`home-manager/programs/claude/default.nix` の `baseSettings` に `showThinkingSummaries = true;` を 1 行追加し、`alwaysThinkingEnabled` との意図が揃う理由をコメントで明記した。

## 動作確認

- Nix 構文: 既存設定への単純なキー追加のみで破壊的変更なし。
- 設定反映: `make switch` 後、インタラクティブセッションで thinking summary が表示されることを確認予定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* Claude のインタラクティブセッションで思考サマリーがデフォルトで表示されるようになりました。AI の推論プロセスをより詳しく確認できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->