### PR TITLE
add: CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 でサブプロセスのクレデンシャルを剥奪

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -10,7 +10,13 @@ let
     showThinkingSummaries = true;
     autoMemoryEnabled = false;
     effortLevel = "high";
-    env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+    env = {
+      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+      # v2.1.83 で追加。Bash / hooks / MCP stdio サーバーのサブプロセス env から
+      # Anthropic・クラウドプロバイダーのクレデンシャルを剥奪する。deny ルールで
+      # 守っている .env / ~/.ssh / ~/.aws / secrets.jsonnet と同じ防御思想の defense-in-depth。
+      CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = "1";
+    };
     # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr 双方の帰属表示を空文字列化して抑止する。
     attribution = {
       commit = "";


### PR DESCRIPTION
## 背景 — 直近の Claude Code アップデート調査

Claude Code の CHANGELOG (v2.1.80 〜 v2.1.117) と最新ドキュメントを確認し、本リポジトリの設定に反映すべき点を棚卸しした。主なアップデートは下記。

### 今回調査した主なアップデート

| バージョン | 概要 |
| --- | --- |
| v2.1.117 (4/22) | Pro/Max の Opus 4.6・Sonnet 4.6 デフォルト effort が `high` に昇格 / 管理設定の保持期間掃除対象拡張 |
| v2.1.113 (4/17) | `sandbox.network.deniedDomains` 追加 / Bash deny が env/sudo/watch ラッパを透過 / `Bash(find:*)` が `-exec`/`-delete` を自動許可しない |
| v2.1.111 (4/16) | Opus 4.7 xhigh effort / `showClearContextOnPlanAccept` / `/less-permission-prompts` skill / `/ultrareview` |
| v2.1.110 (4/15) | `/tui fullscreen`, `/focus`, `autoScrollEnabled` |
| v2.1.108 (4/14) | `ENABLE_PROMPT_CACHING_1H`, `FORCE_PROMPT_CACHING_5M` / recap 機能 / Skill ツールからの組み込みスラッシュコマンド呼び出し |
| v2.1.105 (4/13) | `PreCompact` hook / プラグイン `monitors` マニフェスト / skill description 上限 1,536 文字 |
| v2.1.101 (4/10) | `allowManagedHooksOnly` / Agent Team 参加者が leader の権限モード継承 |
| v2.1.98 (4/9)  | `CLAUDE_CODE_PERFORCE_MODE` / Bash 権限バイパス fix |
| v2.1.97 (4/8)  | status line `refreshInterval` / `workspace.git_worktree` 入力 |
| v2.1.91 (4/2)  | `disableSkillShellExecution` / プラグイン `bin/` 実行ファイル |
| v2.1.89 (4/1)  | `"defer"` permission decision / `PermissionDenied` hook / **`showThinkingSummaries` デフォルト false 化（対応済み）** |
| v2.1.85 (3/26) | Hook `if` フィールド（permission ルール構文でのフィルタ） |
| v2.1.84 (3/26) | `TaskCreated`, `WorktreeCreate` hook / `allowedChannelPlugins` |
| v2.1.83 (3/25) | **`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1`** / `managed-settings.d/` / `CwdChanged`, `FileChanged` hook / `sandbox.failIfUnavailable` / `disableDeepLinkRegistration` |

## 優先度の判定

### 高 → 本 PR で対応

**`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` を `env` に追加**

- v2.1.83 で追加されたセキュリティ機構。Bash ツール / hooks / MCP stdio サーバーのサブプロセス環境から Anthropic およびクラウドプロバイダーのクレデンシャルを剥奪する。
- 既存の `permissions.deny` で `.env` / `~/.ssh/**` / `~/.aws/**` / `secrets.jsonnet` を守っている方針と完全に整合しており、**同じ防御思想の defense-in-depth** として強く推奨できる。
- 現行 hooks (`notify.ts` / `go-fmt.sh` / `statusline.ts`) はいずれも `osascript`・`git`・`go fmt`・`staticcheck` 等ローカルコマンドしか叩かず継承 env のクレデンシャルに依存しない。MCP サーバーも `devin` が Authorization header、`awslabs.aws-documentation-mcp-server` は env を明示定義、`serena`/`deepwiki` は認証不要で、**機能影響なし**。
- 優先度「高」と判定した理由は、 (1) セキュリティ関連、 (2) 既存方針と整合、 (3) 副作用が現行構成で発生し得ない、の 3 点を満たすため。

### 中（本 PR の対象外）

- **`ENABLE_PROMPT_CACHING_1H`** — 長時間セッションのキャッシュ延長。コスト最適化寄りで急務ではない。
- **status line `refreshInterval`** — 表示の自動更新。UX 改善にとどまる。
- **Hook `if` フィールド** — `PostToolUse` の Edit|Write + go-fmt 起動を `.go` のみに絞れるが、現行は `go-fmt.sh` 内で拡張子チェック済みのため効率向上のみ。

### 低（対応不要と判定）

- `autoScrollEnabled` / `showClearContextOnPlanAccept` などの UI オプション。
- 新規 hook (`CwdChanged` / `FileChanged` / `PreCompact` / `PermissionDenied` / `TaskCreated` / `WorktreeCreate`) — 現時点で明確な use case なし。
- `xhigh` effort level（Opus 4.7 用）— 現状の `"high"` 運用で問題なし。
- `disableSkillShellExecution` — skill 活用を阻害するため今の運用に合わない。

### すでに追従済みの項目（対応不要）

- `showThinkingSummaries = true` — v2.1.89 のデフォルト変更に既に追随しコメント注記済み。
- `effortLevel = "high"` — v2.1.117 のデフォルト化後も明示継続で問題なし。
- `attribution = { commit = ""; pr = ""; }` — `includeCoAuthoredBy` 廃止後の置き換え済み。

## Test plan
- [ ] `make check` で flake の評価エラーがないこと
- [ ] `make switch` で `~/.config/claude/settings.json` に `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"` が出力されること
- [ ] Claude Code 再起動後、既存 hooks (`Stop`/`PermissionRequest`/`PostToolUse`) が従来通り動作すること
- [ ] MCP サーバー (`devin` / `awslabs.aws-documentation-mcp-server` / `deepwiki` / `serena`) が正常に接続できること

https://claude.ai/code/session_013vLo7sXCCMGfjwgFkmYpba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Claude の環境設定が更新されました。サブプロセス環境のスクラビング機能が新たに有効になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->