### PR TITLE
update: effortLevel を xhigh に引き上げ (Opus 4.7 向け)

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -9,7 +9,9 @@ let
     # インタラクティブセッションでは thinking block が redacted 表示となる。意図と揃える。
     showThinkingSummaries = true;
     autoMemoryEnabled = false;
-    effortLevel = "high";
+    # v2.1.111 で Opus 4.7 向けに追加された `xhigh`（`high` と `max` の中間）。
+    # alwaysThinkingEnabled = true と合わせて、Opus 4.7 の推論深度を引き上げる。
+    effortLevel = "xhigh";
     env = {
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
       # v2.1.83 で追加。Bash / hooks / MCP stdio サーバーのサブプロセス env から


### PR DESCRIPTION
## 調査対象

Claude Code の CHANGELOG (v2.1.84 〜 v2.1.117) と公式 settings ドキュメントを確認し、現行 dotfiles に反映すべき差分を整理した。

## アップデート内容（v2.1.83 以降で dotfiles 関連のもの）

| バージョン | 内容 |
| --- | --- |
| v2.1.117 | `CLAUDE_CODE_FORK_SUBAGENT` env、Managed settings の `blockedMarketplaces` / `strictKnownMarketplaces` 強制、`/model` 永続化 |
| v2.1.113 | `sandbox.network.deniedDomains` 設定、native binary spawning |
| v2.1.111 | **Opus 4.7 向けに `xhigh` effort level 追加**（`high` と `max` の中間）、Auto mode on Opus 4.7 (Max向け) |
| v2.1.110 | `/tui`, `/focus` コマンド、`autoScrollEnabled` 設定 |
| v2.1.108 | `ENABLE_PROMPT_CACHING_1H` 等の env、`/recap` コマンド |
| v2.1.105 | `PreCompact` hook、plugin `monitors` キー |
| v2.1.89  | `PermissionDenied` hook、`defer` 判定、`CLAUDE_CODE_NO_FLICKER` |
| v2.1.87  | `disableSkillShellExecution` 設定 |
| v2.1.85  | hooks の conditional `if` フィールド |
| v2.1.84  | `TaskCreated` hook、`allowedChannelPlugins` managed setting |

## 優先度判断

### 高: `effortLevel = "xhigh"` への引き上げ ← 本PR対応

- **根拠**:
  - 現行は `effortLevel = "high"` + `alwaysThinkingEnabled = true` + `showThinkingSummaries = true` で「深く考えさせる」方針が明確
  - 使用モデルが Opus 4.7（本リポジトリの想定用途と一致）
  - v2.1.111 で Opus 4.7 専用に追加された `xhigh`（`high` と `max` の中間）は、この方針の直線上にあり設定値の変更だけで恩恵を受けられる
  - 公式 settings スキーマでも `"low" | "medium" | "high" | "xhigh"` が明記された正規値
- **影響範囲**: 1 行変更のみ。リスクは推論時間の微増（`max` ではないため過大ではない）

### 中

- `PermissionDenied` hook (v2.1.89): 既存の `PermissionRequest` hook で通知が取れているため補完的。`bypassPermissions` モード運用下での発火機会も少ない
- `TaskCreated` / `FileChanged` / `CwdChanged` hook: 必要な監視要件が生じてから導入
- `sandbox.network.deniedDomains` (v2.1.113): 現状 `sandbox` ブロック自体を有効化していないため前提整備が先
- `minimumVersion`: 運用ルールとして有用だが自動更新が有効なため急がない

### 低

- `CLAUDE_CODE_FORK_SUBAGENT`: external builds 向け、公式 brew cask 版では不要
- `ENABLE_PROMPT_CACHING_1H`: 主に API キー直叩き向けのコスト最適化
- `PreCompact` / `PostCompact` hook: `autoCompact` を既に無効化しているため発火しない
- `disableSkillShellExecution`: 既存 skills の shell 実行を止めてしまうため採用しない
- `autoScrollEnabled` 等 UI 系: 好みの範囲

## 変更点

- `home-manager/programs/claude/default.nix`: `effortLevel = "high"` → `"xhigh"` に変更し、意図を説明するコメントを追加


---
_Generated by [Claude Code](https://claude.ai/code/session_01NhgfALxbaV4zmsCvhsLmdH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * Claude の推論能力が向上しました。推論レベルが引き上げられ、より深い思考処理が可能になります。

* **新機能**
  * Opus 4.7 のサポートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->