### PR TITLE
add: DISABLE_UPDATES=1 で Claude Code 内蔵 auto-update を抑止

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -18,6 +18,11 @@ let
       # Anthropic・クラウドプロバイダーのクレデンシャルを剥奪する。deny ルールで
       # 守っている .env / ~/.ssh / ~/.aws / secrets.jsonnet と同じ防御思想の defense-in-depth。
       CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = "1";
+      # v2.1.116 で追加。claude-code は Homebrew cask で管理しており、
+      # nix-darwin 側で homebrew.onActivation.upgrade = true として brew に更新を委ねている。
+      # Claude Code 内蔵の auto-update が走ると brew 管理下のバイナリを書き換え、
+      # 次回 `make switch` 時のドリフトや予期せぬバージョン差の原因となるため抑止する。
+      DISABLE_UPDATES = "1";
     };
     # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr 双方の帰属表示を空文字列化して抑止する。
     attribution = {


### PR DESCRIPTION
## 調査対象

Claude Code v2.1.111（dotfiles に痕跡が残る最新参照バージョン）以降のリリースノート、および公式 settings ドキュメントを照合。

## 検出されたアップデート（v2.1.112 〜 v2.1.119）

| version | 主な変更 | 設定/挙動 |
|---|---|---|
| v2.1.112 | Opus 4.7 xhigh / `/effort` スライダー / 「Auto (match terminal)」テーマ / Win PowerShell tool | `effortLevel`（既設定） |
| v2.1.113 | ネイティブバイナリ起動 / `sandbox.network.deniedDomains` / `/loop` Esc キャンセル / macOS の危険パス保護 | `sandbox.network.deniedDomains` |
| v2.1.115 | フォーク subagent (`CLAUDE_CODE_FORK_SUBAGENT=1`) / Pro/Max の既定 effort=high | env / 既定値 |
| v2.1.116 | `DISABLE_UPDATES` env / `/terminal-setup` でスクロール感度 / sandbox 危険パス保護強化 | **`env.DISABLE_UPDATES`** |
| v2.1.117 | agent frontmatter の `mcpServers` を main で読み込み / `blockedMarketplaces` / `strictKnownMarketplaces` | プラグインガバナンス |
| v2.1.118 | vim visual mode / `/cost`+`/stats` → `/usage` 統合 / `/theme` カスタム / Hooks `type: "mcp_tool"` / `wslInheritsWindowsSettings` / autoMode `"$defaults"` | hook 種別 / autoMode |
| v2.1.119 | `/config` の永続化 / **`prUrlTemplate`** / **`CLAUDE_CODE_HIDE_CWD`** / PowerShell auto-approve / Hooks に `duration_ms` | `prUrlTemplate`, env |

## 優先度判定

### 高（本 PR で対応）
- **`env.DISABLE_UPDATES = "1"`**（v2.1.116）
  - `nix-darwin/default.nix` で `claude-code` を Homebrew cask としてインストールし、`homebrew.onActivation.upgrade = true` で brew に更新を委ねる構成。
  - Claude Code 内蔵の auto-update が brew 管理下のバイナリを書き換えると、次回 `make switch` 時のドリフト・予期せぬバージョン差の原因となる。
  - 既設定の `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`（v2.1.83）と同じく defense-in-depth・宣言的単一管理ソースという CLAUDE.md の方針と完全に整合するため高優先。

### 中（本 PR 対象外、別途検討）
- `sandbox.network.deniedDomains`（v2.1.113）— 現状 sandbox セクション未設定。新設には allow/deny ポリシーの全体設計が必要。
- `blockedMarketplaces` / `strictKnownMarketplaces`（v2.1.117）— `enabledPlugins` で公式マーケットプレイスのみ使用中。明示ロックダウンする価値はあるが運用ポリシーとして別途決定が必要。

### 低（本 PR 対象外）
- `prUrlTemplate`（v2.1.119）— 標準 GitHub URL を使用しており不要。
- `CLAUDE_CODE_HIDE_CWD`（v2.1.119）— 装飾的・プライバシー用途で必須性なし。
- Hooks `mcp_tool` 種別（v2.1.118）— 現在の Stop/PermissionRequest/PostToolUse 用途では不要。
- vim visual mode / `/usage` 統合 / カスタムテーマ — 設定不要、挙動変更のみ。
- `CLAUDE_CODE_FORK_SUBAGENT`（v2.1.115/117）— 実験的で安定運用前。

## 変更内容

`home-manager/programs/claude/default.nix` の `env` ブロックに以下を追加：

```nix
# v2.1.116 で追加。claude-code は Homebrew cask で管理しており、
# nix-darwin 側で homebrew.onActivation.upgrade = true として brew に更新を委ねている。
# Claude Code 内蔵の auto-update が走ると brew 管理下のバイナリを書き換え、
# 次回 `make switch` 時のドリフトや予期せぬバージョン差の原因となるため抑止する。
DISABLE_UPDATES = "1";
```

## テスト計画

- [ ] `make switch` で適用後、`~/.config/claude/settings.json` の `env.DISABLE_UPDATES` が `"1"` になっていることを確認
- [ ] Claude Code 起動時に自動更新ダイアログ／アップデート通知が抑止されることを確認
- [ ] `brew upgrade --cask claude-code` で従来通り更新できることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_019hccFhWbkhgBCsDPaX47Md)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Claude Codeの自動更新メカニズムを無効化する設定を追加しました。これにより、Homebrewで管理されたバイナリの変更を防ぎ、Home Managerの実行時にバージョンの不整合を減らすことができます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->