### PR TITLE
add: CLAUDE_CODE_FORK_SUBAGENT=1 でサブエージェントを並列 fork 実行

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -14,6 +14,10 @@ let
     effortLevel = "xhigh";
     env = {
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+      # v2.1.117 で外部ビルド向けに有効化。サブエージェントを fork して走らせることで
+      # CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1" と組み合わせた際に真の並列実行となり、
+      # 複数エージェント同時起動時のレイテンシとオーバーヘッドを削減する。
+      CLAUDE_CODE_FORK_SUBAGENT = "1";
       # v2.1.83 で追加。Bash / hooks / MCP stdio サーバーのサブプロセス env から
       # Anthropic・クラウドプロバイダーのクレデンシャルを剥奪する。deny ルールで
       # 守っている .env / ~/.ssh / ~/.aws / secrets.jsonnet と同じ防御思想の defense-in-depth。


### PR DESCRIPTION
## 背景

Claude Code の最新リリースノート（[CHANGELOG.md](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)）を v2.1.111（現 dotfiles のベースライン）から v2.1.119（最新）まで確認した。dotfiles 設定に反映する価値のある変更を優先度別に整理し、**高** と判定したもののみ反映する。

## アップデート概要 (v2.1.112 → v2.1.119)

### 主な追加・変更
- **v2.1.112**: Opus 4.7 auto mode の bug fix
- **v2.1.113**: `sandbox.network.deniedDomains` 追加 / Bash deny ルールが `env`/`sudo`/`watch` ラッパーに追従 / `Bash(find:*)` が `-exec`/`-delete` を auto-approve しなくなる安全強化
- **v2.1.114**: agent team teammate の permission dialog crash fix
- **v2.1.116**: `/resume` 高速化（最大 67%） / MCP 起動高速化 / `/terminal-setup` 改善 / sandbox auto-allow が dangerous-path safety check を bypass しなくなる
- **v2.1.117**: `CLAUDE_CODE_FORK_SUBAGENT=1` で外部ビルドでも fork 型サブエージェントが有効化 / Pro/Max の Opus/Sonnet 4.6 default effort が `high` に / `cleanupPeriodDays` の対象拡張
- **v2.1.118**: vim visual mode (`v`/`V`) / `/cost` + `/stats` を `/usage` に統合 / hooks が `type: "mcp_tool"` で MCP ツール起動可能 / `DISABLE_UPDATES` env var / auto mode で `"$defaults"` 利用可
- **v2.1.119**: `/config` の persist 挙動強化 / `prUrlTemplate` setting / `CLAUDE_CODE_HIDE_CWD` env var / `--from-pr` が GitLab/Bitbucket/GHE 対応 / status line stdin JSON に `effort.level` / `thinking.enabled` 追加 / hooks `PostToolUse` に `duration_ms`

## 優先度判定

### 高 — 反映 ✅
- **`CLAUDE_CODE_FORK_SUBAGENT=1`** (v2.1.117)
  - 既に opt-in 済みの `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` と直接補完関係。エージェントチーム機能を有効にしている以上、fork 型サブエージェントを併用しないと真の並列実行にならず効果が半減する。
  - 既存の env block に 1 行追加するだけで導入コストが極小。
  - dotfiles の設計思想（バージョン明示コメント付き env 管理）にも自然に整合する。

### 中 — 今回見送り
- **`sandbox.network.deniedDomains`** (v2.1.113): defense-in-depth として魅力的だが、現在 `permissions.defaultMode = "auto"` 運用であり sandbox モードへの移行は別途設計が必要。
- **`prUrlTemplate`** (v2.1.119): GitLab/Bitbucket/Enterprise 用途。現運用は GitHub のみ。
- **`CLAUDE_CODE_HIDE_CWD`** (v2.1.119): UI 表示の好みレベル。
- **status line に `effort.level` / `thinking.enabled`** (v2.1.119): `statusline.ts` を拡張すれば情報量を増やせるが現状の表示で支障なし。

### 低 — 反映不要
- bug fix・内部改善（自動で恩恵を受ける）
- `DISABLE_UPDATES`、vim visual mode、テーマ作成、`type: "mcp_tool"` hook 等は個人 dotfiles の現運用では不要。
- v2.1.113 の Bash deny ラッパー対応は自動で効くため設定変更不要（既存の `Bash(sudo *)` deny が `env sudo …` も捕捉する）。

## 変更内容

`home-manager/programs/claude/default.nix` の `env` ブロックに `CLAUDE_CODE_FORK_SUBAGENT = "1"` を追加。バージョンと意図を示す既存スタイルのコメント付き。

## 動作確認

- [ ] `make check` で flake 設定が通ることを確認
- [ ] `make switch` 後、`~/.config/claude/settings.json` の `env` に `CLAUDE_CODE_FORK_SUBAGENT: "1"` が出力される
- [ ] エージェントチーム機能利用時にサブエージェントが fork で並列起動する

---
_Generated by [Claude Code](https://claude.ai/code/session_01J61E6Py7mXHaTL6s6yaXcF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Claude設定にフォーク型サブエージェント実行機能が追加されました。実験的なエージェントチームと組み合わせて使用する際に、より高い並列処理が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->