### PR TITLE
add: DISABLE_UPDATES=1 で Claude Code 内部 autoupdater を遮断

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -22,6 +22,11 @@ let
       # Anthropic・クラウドプロバイダーのクレデンシャルを剥奪する。deny ルールで
       # 守っている .env / ~/.ssh / ~/.aws / secrets.jsonnet と同じ防御思想の defense-in-depth。
       CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = "1";
+      # v2.1.118 で追加。`DISABLE_AUTOUPDATER` より厳格で `claude update` も含む全更新経路を遮断する。
+      # claude-code は Homebrew cask + `homebrew.onActivation.upgrade = true` で管理しているため、
+      # 内部 autoupdater が走ると Homebrew 管理外の `~/.claude` 配下に並行インストールが生まれ
+      # バージョンの真実の所在が二重化する。Homebrew を単一の真実の所在として固定する。
+      DISABLE_UPDATES = "1";
     };
     # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr 双方の帰属表示を空文字列化して抑止する。
     attribution = {


### PR DESCRIPTION
## 確認したアップデート（Claude Code v2.1.117 以降）

[CHANGELOG.md](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md) を直接参照し、現行 dotfiles に未反映のものを抽出した。

### v2.1.117
- `cleanupPeriodDays` の retention sweep が `~/.claude/tasks/`、`~/.claude/shell-snapshots/`、`~/.claude/backups/` にも適用
- macOS/Linux ネイティブビルドで `Glob`/`Grep` が `bfs`/`ugrep` 経由の Bash 呼び出しに置換（自動）
- Pro/Max の Opus 4.6/Sonnet 4.6 のデフォルト effort が `high` に（当方は `xhigh` 設定済みのため対象外）

### v2.1.118
- **`DISABLE_UPDATES` 環境変数を追加**（`DISABLE_AUTOUPDATER` より厳格で `claude update` も遮断）
- Hooks が `type: "mcp_tool"` で MCP ツールを直接呼び出し可能に
- `autoMode.allow` / `autoMode.soft_deny` / `autoMode.environment` で `"$defaults"` をサポート
- `wslInheritsWindowsSettings`（WSL 限定。macOS では対象外）
- `/cost` と `/stats` を `/usage` に統合
- vim visual mode、custom themes 対応

### v2.1.119
- `prUrlTemplate` 設定（github.com 以外をレビュー先にする場合用）
- `CLAUDE_CODE_HIDE_CWD` 環境変数（startup logo の CWD 表示非表示）
- Hooks `PostToolUse`/`PostToolUseFailure` 入力に `duration_ms` フィールドを自動追加
- `--from-pr` が GitLab/Bitbucket/GHE をサポート
- `blockedMarketplaces` の `hostPattern`/`pathPattern` を強制（managed settings 用）
- Status line stdin に `effort.level` / `thinking.enabled` を追加

## 優先度判定

| 優先度 | 項目 | 判断理由 |
|--------|------|----------|
| **高** | `DISABLE_UPDATES = "1"` (v2.1.118) | claude-code は `nix-darwin/default.nix` の `homebrew.casks` で Homebrew 管理 + `homebrew.onActivation.upgrade = true` で自動アップグレード。内部 autoupdater が走ると `~/.claude/` 配下に Homebrew 管理外の並行インストールが発生し、バージョンの真実の所在が二重化する。`DISABLE_AUTOUPDATER` だと自動更新のみ抑止だが、`DISABLE_UPDATES` は `claude update` も含めて全更新経路を遮断するため、Homebrew を単一の真実の所在として固定できる。 |
| 中 | 該当なし | `duration_ms` (v2.1.119) はフック入力に自動付与されるため、利用したくなった時点でフック側を改修すれば足りる。statusline JSON の `effort.level`/`thinking.enabled` も同様。 |
| 低 | `prUrlTemplate` / `CLAUDE_CODE_HIDE_CWD` / `mcp_tool` フック / vim visual / `/usage` / `wslInheritsWindowsSettings` / `blockedMarketplaces` / `autoMode.*` の `"$defaults"` | github.com 以外を使用していない、UI 表示の好み、現状で困っていない、macOS で対象外、managed settings 用、現行設定で `autoMode.*` を未使用のため移行不要、いずれも今すぐ反映する必然性なし。 |

## 変更内容

- `home-manager/programs/claude/default.nix` の `env` ブロックに `DISABLE_UPDATES = "1"` を追加
- 採否理由（Homebrew cask + `onActivation.upgrade = true` を真実の所在として固定する）を既存の env コメント慣習に倣ってインライン記載

## 動作確認 TODO

- [ ] `make switch` で `~/.config/claude/settings.json` の `env.DISABLE_UPDATES` が `"1"` になることを確認
- [ ] Claude Code 再起動後、`/doctor` 等で内部 autoupdater が無効化されていることを確認
- [ ] `brew upgrade --cask claude-code` 経由のバージョン更新が引き続き機能することを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01GZzj1jLVpv8RB9K21EWnUg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定変更**
  * Claude Code環境設定が更新されました。自動更新チェック機能が無効化され、更新確認やインストールのプロンプトは表示されなくなります。Homebrew経由でインストールされたバージョンのみが使用されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->