### PR TITLE
add: skillのinline shell実行とdeep link登録を無効化しdefense-in-depthを強化

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -33,6 +33,15 @@ let
       commit = "";
       pr = "";
     };
+    # v2.1.91 で追加。skill の inline shell 実行経路を遮断する。`permissions.deny` で守っている
+    # 機密ファイル防御と `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` の defense-in-depth 思想を skill 層まで拡張し、
+    # marketplace 由来の skill 経由で任意コード実行されるリスクを排除する。自作スキル群は markdown 命令のみで
+    # inline shell exec を使っていないため破壊的変更にはならない。
+    disableSkillShellExecution = true;
+    # v2.1.83 で追加。`claude-cli://` プロトコルハンドラーの OS 登録を抑止する。
+    # 通常はターミナル経由で claude を起動しており deep link は使っていないため機能損失はなく、
+    # URL scheme 経由の引数注入・意図しない起動経路を遮断する。
+    disableDeepLinkRegistration = true;
     enabledPlugins = {
       "typescript-lsp@claude-plugins-official" = true;
       "pyright-lsp@claude-plugins-official" = true;


### PR DESCRIPTION
## サマリー

Claude Code v2.1.118 → v2.1.119 のリリースノート（13リリース分）を確認し、現状の dotfiles の防御思想（`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` / `permissions.deny` で機密ファイル除外 / `DISABLE_UPDATES=1` で Homebrew を真実の所在に固定）と直接合致する2つのセキュリティ設定を追加した。

```nix
disableSkillShellExecution = true;   # v2.1.91 で追加
disableDeepLinkRegistration = true;  # v2.1.83 で追加
```

---

## 確認した更新内容（v2.1.118 → v2.1.119、計13リリース）

### settings.json に新規追加された主な設定キー

| バージョン | キー | 内容 |
|---|---|---|
| v2.1.119 | `prUrlTemplate` | フッター PR バッジのカスタム URL |
| v2.1.113 | `sandbox.network.deniedDomains` | sandbox 内のドメイン単位ブロック |
| v2.1.110 | `autoScrollEnabled` | fullscreen の自動スクロール抑止 |
| v2.1.97 | `refreshInterval` | status line スクリプトの再実行間隔 |
| **v2.1.91** | **`disableSkillShellExecution`** | **skill の inline shell 実行を無効化** |
| v2.1.92 | `forceRemoteSettingsRefresh` | managed settings の強制再読み込み |
| v2.1.84 | `allowedChannelPlugins` | channel plugin allowlist (Team/Enterprise) |
| **v2.1.83** | **`disableDeepLinkRegistration`** | **`claude-cli://` プロトコル登録を抑止** |
| v2.1.83 | `sandbox.failIfUnavailable` | sandbox 不可時にエラー終了 |

### 新しい hooks イベント / 機能

- v2.1.118: hooks の `type: "mcp_tool"` で MCP tool を呼び出し可能に
- v2.1.105: `PreCompact` hook の `decision:"block"` / exit code 2 で compaction ブロック
- v2.1.105: plugin の `monitors` manifest による background monitor
- v2.1.89: `PermissionDenied` hook（auto mode 拒否時）/ `"defer"` permission decision
- v2.1.85: hooks の conditional `if` フィールド
- v2.1.84: `TaskCreated` / `WorktreeCreate` hook
- v2.1.83: `CwdChanged` / `FileChanged` hook
- v2.1.78: `StopFailure` hook

### 新しい環境変数

- v2.1.119: `CLAUDE_CODE_HIDE_CWD`
- v2.1.108: `ENABLE_PROMPT_CACHING_1H` / `FORCE_PROMPT_CACHING_5M`
- v2.1.98: `CLAUDE_CODE_PERFORCE_MODE`
- v2.1.89: `CLAUDE_CODE_NO_FLICKER` / `MCP_CONNECTION_NONBLOCKING`
- v2.1.84: `CLAUDE_STREAM_IDLE_TIMEOUT_MS`
- (Windows) `CLAUDE_CODE_USE_POWERSHELL_TOOL`、(Bedrock) `CLAUDE_CODE_USE_MANTLE` 等

### Permission / セキュリティ強化

- v2.1.113: macOS `/private/{etc,var,tmp,home}` を危険削除対象として扱う
- v2.1.113: Bash deny ルールが `env` / `sudo` / `watch` / `ionice` / `setsid` ラッパー経由のバイパスを検出
- v2.1.113: `Bash(find:*)` ルールが `-exec` / `-delete` を auto-approve しない
- v2.1.110: `PermissionRequest` hooks の `updatedInput` が deny ルールをバイパスしない（修正）
- v2.1.101: `permissions.deny` が `PreToolUse` hook を上書き（修正）
- v2.1.98: 複合 Bash コマンド・env-var prefix・`/dev/tcp` リダイレクト経由のバイパス遮断
- v2.1.89: `Edit(//path/**)` / `Read(//path/**)` の symlink ターゲット検証
- v2.1.77: `Bash(...)` の "Always Allow" を複合コマンドで分解判定

### Deprecated / 削除

- v2.1.92: `/tag` / `/vim` コマンド削除
- v2.1.89: `cleanupPeriodDays: 0` を validation error 化
- v2.1.83: `TaskOutput` tool 廃止予定
- (既知) `DISABLE_AUTOUPDATER` → `DISABLE_UPDATES`（既に移行済み）
- (既知) `includeCoAuthoredBy` → `attribution`（既に移行済み）

### 新スラッシュコマンド / Skill

`/tui`, `/recap` (`/undo` alias), `/focus`, `/powerup`, `/ultrareview`, `/less-permission-prompts`, `/team-onboarding`, `/proactive` (`/loop` alias) など

---

## 優先度判断

### 高（このPRで対応）

#### 1. `disableSkillShellExecution = true` (v2.1.91)

**なぜ高か**:
- 既存の `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = 1` と完全に同一の defense-in-depth 思想で、防御範囲を skill 層まで拡張する。
- skill は marketplace やプラグイン経由で増えていく性質があり、inline shell 実行経路はサプライチェーン経由の任意コード実行ベクタとして機能しうる。`permissions.deny` で `.env` / `~/.ssh` / `~/.aws` / `secrets.jsonnet` を守っているのと同じ防御を skill 経由でも一貫させる。
- 自作スキル群（`home-manager/programs/claude/skills/*/SKILL.md`）は markdown 命令のみで構成されており、inline shell exec を使っていない。すべての shell 呼び出しは Bash tool 経由で `permissions.allow` / `permissions.deny` のルールに従う。よって破壊的変更にはならない。

#### 2. `disableDeepLinkRegistration = true` (v2.1.83)

**なぜ高か**:
- `claude-cli://` URL scheme は v2.1.85 で 5,000 字制限が入ったが、登録自体を無効化する方が攻撃面の根本除去となる。
- 通常運用ではターミナル経由で claude を起動しており（statusLine / fileSuggestion / hooks 経路はそのまま動く）、deep link は使用していないため機能損失はゼロ。
- macOS の URL scheme handler を Claude Code が握ることで、ブラウザ・他アプリから意図しない引数で claude が起動される経路を遮断できる。

### 中（このPRでは対応しない）

- **hooks の `if` 条件 (v2.1.85)**: `PostToolUse.matcher = "Edit|Write"` を `*.go` 限定に絞る最適化。go-fmt.sh 内で既に拡張子チェック済みのため実害は無く、最適化に留まる。
- **`PermissionDenied` hook (v2.1.89)**: auto mode で deny されたタイミングで notify.ts を流用して通知できる。便利機能だが必須ではない。
- **`StopFailure` hook (v2.1.78)**: Stop hook の API エラー版。可観測性向上だが緊急性は低い。
- **`sandbox.failIfUnavailable` / `sandbox.network.deniedDomains`**: sandbox 機能を有効化していないので恩恵が無い。

### 低

- UI 系設定 (`autoScrollEnabled`, `refreshInterval`, `prUrlTemplate`, `/tui` など): 個人の好みの範疇。
- `CLAUDE_CODE_HIDE_CWD`: cosmetic。
- `ENABLE_PROMPT_CACHING_1H`: prompt cache TTL 延長。billing 影響を見つつ別途検討。
- Bedrock / Vertex / PowerShell / Windows / Linux sandbox 関連: aarch64-darwin では非該当。

---

## 動作確認

- `disableSkillShellExecution`: 自作スキルは Bash tool 経由でしかコマンドを呼んでおらず、SKILL.md フロントマターも `name` / `description` / `model` / `effort` / `arguments` のみで shell 実行関連フィールド（`run:`, `allowed-tools` の inline-exec 系等）は使っていないことを確認済み。
- `disableDeepLinkRegistration`: deep link を起点とする運用フローは無し（statusLine / hooks / commands / skills の参照経路はすべてローカルファイル）。

`make check` / `make switch` で nix 設定を検証する想定。

---
_Generated by [Claude Code](https://claude.ai/code/session_01XS32BAFbV8h2R4XQ3Sb4sN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Claudeの設定に新しい構成オプションを追加しました。スキルのインラインシェル実行を無効にするオプションと、`claude-cli://` ディープリンクプロトコルハンドラーの登録を無効にするオプションが利用可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->