### PR TITLE
chore(flake): bump 25.05 → 25.11 (Xantusia) — 25.05 は EOL 済

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,13 @@
   description = "imsugeno's dotfiles and nix-darwin configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.05-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
     nix-darwin = {
-      url = "github:nix-darwin/nix-darwin/nix-darwin-25.05";
+      url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.05";
+      url = "github:nix-community/home-manager/release-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
## 調査サマリ

リリースノート / 最新ドキュメントを横断的に確認したアップデートと、本リポジトリへ反映する優先度の判定結果。

### 検出したアップデート

| 領域 | 現状 (flake.lock: 2025-09 ロック) | 最新 (2026-05 時点) | 概要 |
|---|---|---|---|
| **nixpkgs** | `nixpkgs-25.05-darwin` (Warbler) | `nixpkgs-25.11-darwin` (Xantusia, 2025-11 リリース) | 25.05 は **2025-12-31 で EOL**。セキュリティ更新が約 5 ヶ月停止中。 |
| **nix-darwin** | `nix-darwin-25.05` | `nix-darwin-25.11` (ブランチ存在を確認) | 同上の nixpkgs 系列に追従するブランチ。 |
| **home-manager** | `release-25.05` | `release-25.11` (2026-05-03 まで活発に更新) | macOS で `targets.darwin.copyApps.enable` が既定化等の breaking change あり。ただし `home.stateVersion` ゲート式のため、ステートを上げない限り発火しない。 |
| **Claude Code** | コメント上は v2.1.118 を意識した設定 | v2.1.128 まで進行 | 主に追加機能 (`spinnerTipsOverride.excludeDefault` / `CLAUDE_CODE_HIDE_CWD` / `CLAUDE_CODE_CERT_STORE` / `--plugin-dir` の zip 対応 / MCP `alwaysLoad` / PostToolUse の `updatedToolOutput` 等)。既存の `effortLevel = "xhigh"` 等の設定は破壊的変更の対象外で、現行のままでも動作する。 |
| **Homebrew 配下のツール** (claude / claude-code / cursor / iterm2 / karabiner-elements 等) | — | — | `homebrew.onActivation = { autoUpdate = true; upgrade = true; }` で自動追従済。dotfiles 側に固定ピンが無いため宣言的な追従作業は不要。 |

### 優先度判定

#### 🔴 高 — **Nix 系列 25.05 → 25.11**
- 25.05 (Warbler) は **2025-12-31 EOL 済**。NixOS は EOL 後セキュリティパッチを受け取らないため、長期化するほど CVE 対応の遅延が積み上がる。
- 25.11 への追従は単純なブランチ参照差し替えで済み、影響範囲が小さい (本リポジトリは Darwin 専用 / `home.stateVersion = "24.11"` 据え置きで gated breaking change は不発火)。
- → **本 PR で対応**。

#### 🟡 中 — **Claude Code v2.1.119+ の新機能取り込み**
- `CLAUDE_CODE_HIDE_CWD` / `CLAUDE_CODE_CERT_STORE` / `spinnerTipsOverride.excludeDefault` 等は cosmetic / 任意。
- 現行 `xhigh` / `alwaysThinkingEnabled` / `agent teams` 系の設定は引き続き有効で、緊急性なし。
- → **本 PR では見送り**。利用者の好みに応じて別 PR で追加するのが適切。

#### 🟢 低 — **Homebrew 経由ツールの追従**
- `onActivation.upgrade = true` により自動追従されるため、宣言ファイル側で何かを変える必要なし。
- → **本 PR では見送り**。

## 変更内容

`flake.nix` のフレーク入力 3 本を `25.05` → `25.11` に揃えるのみ。

```diff
- nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.05-darwin";
+ nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
- url = "github:nix-darwin/nix-darwin/nix-darwin-25.05";
+ url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
- url = "github:nix-community/home-manager/release-25.05";
+ url = "github:nix-community/home-manager/release-25.11";
```

`home.stateVersion` は **意図的に `"24.11"` のまま** にしている。home-manager 25.11 で macOS 向けに `targets.darwin.copyApps.enable` が既定化される等の breaking change は state-version ゲートのため、これを据え置くことで挙動の連続性を保つ。stateVersion を上げる判断は別 PR で扱うのが安全。

## マージ前の手順

本 PR は flake.nix のみ変更しており、**`flake.lock` は未更新**。これは PR 作成環境に `nix` が無いことに由来する (リポジトリの方針: Nix コマンドはローカル運用)。マージ前後で必ず以下のいずれかを実施してください。

```bash
make update     # = nix flake update。lock を 25.11 系の最新コミットへ巻き直す
make rebuild    # update + mcp + switch を一気に実行
```

## テスト計画

- [ ] `make check` (= `nix flake check`) で評価エラーが出ないこと
- [ ] `make update` で `flake.lock` の `nixpkgs / nix-darwin / home-manager` の `original.ref` が `25.11` 系に更新されていること
- [ ] `make switch` が成功し、`darwin-rebuild` が完走すること
- [ ] `claude` / `cursor` / `zsh` / `git` / `mise` 等、各 program の動作確認

## 参考

- [NixOS 25.05 EOL (endoflife.date)](https://endoflife.date/nixos)
- [NixOS 25.11 リリースアナウンス](https://nixos.org/blog/announcements/2025/nixos-2511/)
- [home-manager release-25.11 issue #8212](https://github.com/nix-community/home-manager/issues/8212)
- [Claude Code CHANGELOG](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)

https://claude.ai/code/session_01T3eHKaVMidyz6d4V9oBZkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3eHKaVMidyz6d4V9oBZkZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存パッケージのバージョンを更新しました。nixpkgs、nix-darwin、home-manager のバージョンが 25.05 から 25.11 にアップデートされました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->