### PR TITLE
add: ENABLE_PROMPT_CACHING_1H=1 でプロンプトキャッシュ TTL を 1 時間に延長

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -27,6 +27,12 @@ let
       # 内部 autoupdater が走ると Homebrew 管理外の `~/.claude` 配下に並行インストールが生まれ
       # バージョンの真実の所在が二重化する。Homebrew を単一の真実の所在として固定する。
       DISABLE_UPDATES = "1";
+      # v2.1.108 で追加・v2.1.128 で正式対応。プロンプトキャッシュ TTL を 5 分 → 1 時間に延長する。
+      # Opus 4.7 + effortLevel = "xhigh" + AGENT_TEAMS / FORK_SUBAGENT という重い構成では、
+      # 拡張思考や並列サブエージェントが走る間に 5 分の TTL を簡単に超え、再書き込みコストが嵩む。
+      # 1h 書き込みは 5m の 2x コストだが、TTL 内に 2 回再ヒットすれば元が取れる前提で、
+      # ユーザーが確認・思考する数分〜数十分のポーズを跨いでもキャッシュが生きる方が正味でメリットが大きい。
+      ENABLE_PROMPT_CACHING_1H = "1";
     };
     # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr 双方の帰属表示を空文字列化して抑止する。
     attribution = {


### PR DESCRIPTION
## サマリ

`home-manager/programs/claude/default.nix` の `env` に `ENABLE_PROMPT_CACHING_1H = "1"` を追加し、Claude Code のプロンプトキャッシュ TTL を 5 分 → 1 時間に延長する。

## Claude Code v2.1.118 以降のアップデート概要

現在 dotfiles に取り込み済みの最新は v2.1.118 (`DISABLE_UPDATES`)。それ以降のリリース (v2.1.119 〜 v2.1.133) を整理すると以下のような追加・変更があった。

| バージョン | 主要な追加・変更 |
| --- | --- |
| v2.1.119 | `prUrlTemplate` / `CLAUDE_CODE_HIDE_CWD` / `--from-pr` の GitLab/Bitbucket 対応 / `/config` の永続化 |
| v2.1.120 | Windows で Git Bash 不要化 / `claude ultrareview` 非対話実行 / `AI_AGENT` 自動セット |
| v2.1.121 | MCP の `alwaysLoad` / `claude plugin prune` / PostToolUse の出力置換 |
| v2.1.122 | `ANTHROPIC_BEDROCK_SERVICE_TIER` |
| v2.1.126 | `claude project purge` / `--dangerously-skip-permissions` の保護パスバイパス制御 |
| v2.1.128 | **`ENABLE_PROMPT_CACHING_1H` で 1h TTL に正式対応** / `/mcp` のツール数表示 |
| v2.1.129 | `--plugin-url` / `CLAUDE_CODE_FORCE_SYNC_OUTPUT` / `CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE` / `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY` |
| v2.1.131 | Windows VS Code 拡張・Mantle 認証ヘッダーのバグ修正 |
| v2.1.132 | `CLAUDE_CODE_SESSION_ID` / `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN` / 多数のバグ修正 |
| v2.1.133 | `worktree.baseRef` / `sandbox.bwrapPath` / `sandbox.socatPath` / `parentSettingsBehavior` / フックの `effort.level` / `$CLAUDE_EFFORT` |

## 優先度判断

### 【高】今回反映 — `ENABLE_PROMPT_CACHING_1H = "1"`
本リポジトリの Claude 設定は以下のような **「重い使い方」** に最適化されている。

- `effortLevel = "xhigh"` (Opus 4.7 向けの最大に近い推論深度)
- `alwaysThinkingEnabled = true` + `showThinkingSummaries = true`
- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"` + `CLAUDE_CODE_FORK_SUBAGENT = "1"` (並列サブエージェント)

この構成では拡張思考と並列エージェントが走る間に **5 分の TTL を簡単に超過** し、ユーザー側の確認・編集・思考の数分〜数十分のポーズを跨ぐと毎回キャッシュ再書き込みが走る。
1h TTL は書き込みコストが 5m の 2x だが、TTL 内に **2 回再ヒットすれば元が取れる**ため、本リポジトリの使用パターンでは正味でコスト/レート効率が改善する。**重い設定との相乗効果が最も大きく、即時メリットが見込める** ため高優先度とした。

### 【中】見送り（必要性が状況依存）
- `CLAUDE_CODE_HIDE_CWD` — 画面共有時のプライバシー保護目的。普段は cwd 表示の方が便利なため即時必要性は低い。
- `worktree.baseRef` — git worktree のブランチ元指定。本リポジトリは worktree を多用していないため見送り。
- `parentSettingsBehavior` — 多層管理設定をしていないため不要。
- `alwaysLoad` MCP オプション — 現状の MCP 構成で問題なし。

### 【低】見送り（即時不要）
- `prUrlTemplate` — デフォルトの GitHub PR URL で十分。
- `autoScrollEnabled` — デフォルト `true` で問題なし。
- `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN` / `CLAUDE_CODE_FORCE_SYNC_OUTPUT` — 通常のターミナルでは不要。
- `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY` — ゲートウェイ未使用。
- `sandbox.network.deniedDomains` — sandbox は Linux PID namespace 中心で、本環境 (aarch64-darwin) では適用範囲が限定的。
- `ANTHROPIC_BEDROCK_SERVICE_TIER` — Bedrock を使っていないため無関係。

## Test plan

- [ ] `make check` で flake 設定の検証
- [ ] `make switch` で nix-darwin 設定を適用
- [ ] `claude` 起動後、API レスポンスに `ephemeral_1h_input_tokens` が現れる（`ephemeral_5m_input_tokens` ではなく）ことを確認

https://claude.ai/code/session_012RLY1vZp8Z3CFv7PYUh39j

---
_Generated by [Claude Code](https://claude.ai/code/session_012RLY1vZp8Z3CFv7PYUh39j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Claude のプロンプトキャッシュの有効期間を 5 分から 1 時間に延長し、より長い処理でのパフォーマンスを向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->