### PR TITLE
add: autoMode.hard_deny で auto mode 分類器に意図ベースの defense-in-depth を追加

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -38,6 +38,20 @@ let
       "pyright-lsp@claude-plugins-official" = true;
       "gopls-lsp@claude-plugins-official" = true;
     };
+    # v2.1.136 で追加。`permissions.defaultMode = "auto"` の auto mode 分類器に対し、
+    # user intent / allow 例外に関係なく無条件で拒否させる自然言語ルール。
+    # `permissions.deny` の構文ベース（`Bash(sudo *)` 等）はシェル経由の回避
+    # （`bash -lc "sudo ..."` 等）で抜けうるため、同じ defense-in-depth 思想を意図ベースで二重化する。
+    # `$defaults` で組み込みルールを継承する。
+    autoMode = {
+      hard_deny = [
+        "$defaults"
+        "Never read .env, .env.local, or any other .env.* files in any directory"
+        "Never read files under ~/.ssh, ~/.aws, or any secrets.jsonnet file"
+        "Never run sudo or su commands, even via shell wrappers, subshells, or pipes"
+        "Never run git push — the user pushes manually"
+      ];
+    };
     permissions = {
       defaultMode = "auto";
       allow = [


### PR DESCRIPTION
## サマリ

Claude Code v2.1.119 〜 v2.1.138 のリリースノートと最新ドキュメントを精査し、現状の dotfiles に未反映の変更を抽出して優先度を高・中・低で評価。高優先度と判断した **`autoMode.hard_deny`**（v2.1.136）を `home-manager/programs/claude/default.nix` に追加する。

## 調査対象アップデート（v2.1.119 〜 v2.1.138）

`home-manager/programs/claude/default.nix` 現状の参照: v2.1.83 / v2.1.111 / v2.1.117 / v2.1.118。CHANGELOG をその後の v2.1.119 から最新 v2.1.138 まで精査した結果、追加された主な設定可能項目は以下:

| 項目 | バージョン | 種類 |
|---|---|---|
| `prUrlTemplate` | v2.1.119 | settings |
| `CLAUDE_CODE_HIDE_CWD` | v2.1.119 | env |
| `PostToolUse` hook `duration_ms` 入力 | v2.1.119 | hooks |
| Status line stdin に `effort.level` / `thinking.enabled` | v2.1.119 | statusline |
| MCP `alwaysLoad: true` | v2.1.121 | MCP config |
| `PostToolUse` の `hookSpecificOutput.updatedToolOutput` 全ツール対応 | v2.1.121 | hooks |
| `ANTHROPIC_BEDROCK_SERVICE_TIER` | v2.1.122 | env (Bedrock) |
| `--dangerously-skip-permissions` 拡張 | v2.1.126 | CLI |
| `EnterWorktree` の base 変更（一旦 HEAD、後で fresh に戻る） | v2.1.128 / v2.1.133 | 内部挙動 |
| `--plugin-url`, `skillOverrides`, `CLAUDE_CODE_FORCE_SYNC_OUTPUT`, `CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE` | v2.1.129 | CLI/settings/env |
| `CLAUDE_CODE_SESSION_ID` / `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN` | v2.1.132 | env |
| `worktree.baseRef` (`fresh` \| `head`), `sandbox.bwrapPath` / `sandbox.socatPath`, `parentSettingsBehavior`, hooks の `effort.level` / `$CLAUDE_EFFORT` | v2.1.133 | settings/hooks |
| `CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL`, **`autoMode.hard_deny`** | v2.1.136 | env/settings |

## 優先度判定

### 高（採用）

- **`autoMode.hard_deny` (v2.1.136)**
  - 採用理由: 現状の `permissions.defaultMode = "auto"` 配下で、auto mode 分類器が user intent や allow 例外に関係なく無条件で拒否するルールとして機能する。既存の `permissions.deny`（`Bash(sudo *)`, `Read(.env)`, `Read(~/.ssh/**)`, `Read(~/.aws/**)`, `Read(**/secrets.jsonnet)`, `Bash(git push*)` 等）は構文マッチに依存しており、`bash -lc "sudo ..."` や複雑なシェル経由の回避でルールをすり抜ける余地が残る。`autoMode.hard_deny` は自然言語の意図ベースで分類器に判断させるため、構文ベース防御と直交する第二の防壁になる。これは既存の `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` や `deny` ルールと同じ defense-in-depth 設計思想の延長線上にあり、優先度高と判断した。

### 中（不採用）

- **MCP `alwaysLoad: true` (v2.1.121)**: serena 等の常用サーバーで tool-search deferral を回避できるが、`alwaysLoad: true` は起動時に最大 5 秒の connect block を強制し、`MCP_CONNECTION_NONBLOCKING=1` の効果も無効化する。現状の MCP サーバー数なら deferral 運用で問題ないため見送り。
- **`CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE` (v2.1.129)**: 既存の `DISABLE_UPDATES=1`（Homebrew 単一の真実の所在に固定）と方針が真逆。採用すれば自動更新を再導入することになるため不採用。

### 低（不採用）

- `prUrlTemplate` / `CLAUDE_CODE_HIDE_CWD` / `skillOverrides`: UI または個人的好みの範疇。
- `worktree.baseRef`: v2.1.133 でデフォルトが `fresh` に戻り、明示設定不要。
- `sandbox.bwrapPath` / `sandbox.socatPath` / WSL 系 / Bedrock / Vertex / Windows 固有: macOS aarch64-darwin の対象外。
- `ANTHROPIC_BEDROCK_SERVICE_TIER` / `CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL`: Bedrock または企業 OTel 環境向けで対象外。
- `CLAUDE_CODE_SESSION_ID` / hooks の `duration_ms` / `$CLAUDE_EFFORT`: 自動付与で、現状の hooks（`notify.ts`, `go-fmt.sh`）が利用していない。必要が出てから対応。
- バグ修正系: 環境固有または既に影響ない範囲。

## 変更内容

`home-manager/programs/claude/default.nix` の `baseSettings` に `autoMode.hard_deny` を追加:

- `$defaults` で組み込みルールを継承
- `.env` / `.env.*` 系ファイルの参照禁止
- `~/.ssh` / `~/.aws` / `secrets.jsonnet` の参照禁止
- `sudo` / `su` の実行禁止（シェル経由の回避も含めて明示）
- `git push` の禁止（ユーザー自身が push する運用）

## テスト計画

- [ ] `make switch` で nix-darwin 設定を適用
- [ ] `~/.config/claude/settings.json` に `autoMode.hard_deny` が出力されることを確認
- [ ] Claude Code セッションで `.env` 読み取りや `sudo` 実行を試み、auto mode 分類器が拒否することを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01VErraiDV9KxygJXuTwp9Bp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Claude設定に新しい自動モード用のセキュリティ制限を追加しました。機密ファイル（.env、SSH鍵、AWS認証情報）へのアクセスをブロックし、特権コマンド実行とgit pushを禁止します。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imsugeno/dotfiles/pull/15)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->