### PR TITLE
claude: worktree.baseRef を &quot;head&quot; に明示固定（v2.1.143 破壊的変更対応）

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -44,6 +44,17 @@ let
       "pyright-lsp@claude-plugins-official" = true;
       "gopls-lsp@claude-plugins-official" = true;
     };
+    # v2.1.133 で追加・v2.1.143 でデフォルトが "head" → "fresh" (origin/<default>) に変更された。
+    # Agent tool の `isolation: "worktree"` / `--worktree` / `EnterWorktree` 起動時、
+    # デフォルトの "fresh" だと未push のローカル commits を含まない origin/<default> から
+    # worktree が作成され、作業中の WIP が agent 側に渡らない。
+    # サブエージェント並列実行（AGENT_TEAMS / FORK_SUBAGENT）で in-progress な変更を
+    # そのまま渡したい運用なので、"head" で旧挙動を明示固定する。
+    # autoupdate 経路（DISABLE_UPDATES=1 で塞いでいるが Homebrew 経由の昇格は走る）で
+    # サイレントに挙動が変わるのを防ぐ。
+    worktree = {
+      baseRef = "head";
+    };
     # v2.1.136 で追加。`permissions.defaultMode = "auto"` の auto mode 分類器に対し、
     # user intent / allow 例外に関係なく無条件で拒否させる自然言語ルール。
     # `permissions.deny` の構文ベース（`Bash(sudo *)` 等）はシェル経由の回避


### PR DESCRIPTION
## 背景：Claude Code v2.1.137 〜 v2.1.145 のアップデート調査

dotfiles 現状の Claude Code 設定は v2.1.136 までを織り込み済み（コメント参照）。今回 v2.1.145 までの差分を release notes / 公式ドキュメントで確認し、本リポジトリに反映すべきかを整理した。

### v2.1.137 〜 v2.1.145 の主な変更点

| バージョン | 変更内容 | 種別 |
|---|---|---|
| v2.1.143 | **`worktree.baseRef` のデフォルトが `"head"` → `"fresh"`（`origin/<default>`）に変更** | **破壊的** |
| v2.1.143 | `worktree.bgIsolation` 追加（`"worktree"` / `"none"`） | 新設定 |
| v2.1.143 | `sandbox.bwrapPath` / `sandbox.socatPath` 追加 | Linux/WSL 専用 |
| v2.1.143 | `parentSettingsBehavior` (SDK managedSettings 統合) | 新設定 |
| v2.1.143 | PowerShell `-ExecutionPolicy Bypass`（Windows） | 適用外 |
| v2.1.143 | Stop hook 8 連続 block で打ち切り（`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` で上書き可） | 安全機能 |
| v2.1.142 | Fast mode が Opus 4.7 を使用するように | 機能改善 |
| v2.1.142 | `MCP_TOOL_TIMEOUT` が `fetch` タイムアウトにも適用 | 挙動変更 |
| v2.1.141 | フック `terminalSequence` フィールド追加 | 新オプション |
| v2.1.141 | `ANTHROPIC_WORKSPACE_ID` / `CLAUDE_CODE_PLUGIN_PREFER_HTTPS` 環境変数 | 新環境変数 |
| v2.1.141 | `prUrlTemplate` 設定 | 新設定 |
| v2.1.139 | `PostToolUse` の `continueOnBlock` オプション | 新オプション |
| v2.1.139 | Hook `args: string[]`（exec 形式、shell 経由なし） | 新オプション |
| v2.1.139 | Hook `type: "mcp_tool"` 追加 | 新オプション |
| v2.1.139 | `/goal` コマンド・Agent View（`claude agents`） | 新機能 |
| v2.1.145 | `claude agents --json`、`/resume --bg` 対応など | 機能改善 |

## 優先度判定

### 高 ←【今回対応】

- **`worktree.baseRef = "head"` の明示固定**
  - v2.1.143 でデフォルトが `"fresh"`（`origin/<default>` から worktree を切る）に変わったため、Agent tool の `isolation: "worktree"` や `--worktree` / `EnterWorktree` 起動時に **未 push のローカル commits が反映されない** 回帰が発生する。
  - 現設定は `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` + `CLAUDE_CODE_FORK_SUBAGENT=1` でサブエージェント並列実行を前提としており、in-progress な作業を agent に渡したい運用とそぐわない。
  - `DISABLE_UPDATES=1` を入れているが Homebrew cask 経由の昇格は走るため、いずれサイレントに挙動が切り替わる。明示固定して旧挙動を保つ意義が高い。
  - 既存の defense-in-depth 思想（`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`、`autoMode.hard_deny` など）と合致。

### 中（今回見送り）

- **Fast mode の Opus 4.7 切替（v2.1.142）**: 既に `effortLevel = "xhigh"` で Opus 4.7 を前提にしているため、追加対応なし。
- **`MCP_TOOL_TIMEOUT` の fetch 適用（v2.1.142）**: 現状リモート MCP サーバーで遅延起点の問題が観測されていないため不要。

### 低（今回見送り）

- `worktree.bgIsolation`: 現デフォルト `"worktree"` で問題なし。
- `PostToolUse` の `continueOnBlock`: 既存の `go-fmt.sh` は常時 `exit 0` で拒否しないため効果限定的。
- Hook `args: string[]` (exec 形式): 既存 hook は shebang スクリプトで shell injection リスクなし。
- `terminalSequence`: 既に `notify.ts` で通知実装済み。
- `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`: デフォルト 8 で既に保護。
- `CLAUDE_CODE_PLUGIN_PREFER_HTTPS`: 現環境特有の必要性なし。
- `prUrlTemplate`: GitHub 標準のレビュー URL で支障なし。
- `sandbox.*` / PowerShell 関連: macOS では適用外。

## 変更内容

`home-manager/programs/claude/default.nix` の `baseSettings` に以下を追加：

```nix
worktree = {
  baseRef = "head";
};
```

これで生成される `~/.config/claude/settings.json` に `{"worktree": {"baseRef": "head"}}` が出力され、worktree 起動時のベースが常に HEAD（＝現ブランチ＋未 push 変更）に固定される。

## 動作確認

- Nix の構文チェックはこの環境にツールが無いため未実施。`make switch` または `make check` でリビルド時に検証してください。
- `~/.config/claude/settings.json` を開き、`worktree.baseRef` が `"head"` になっていることを確認。

## 参考

- [Claude Code Changelog](https://code.claude.com/docs/en/changelog)
- [Run parallel sessions with worktrees](https://code.claude.com/docs/en/worktrees)
- [Claude Code v2.1.133 リリースノート](https://claude-world.com/articles/claude-code-21133-release/)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEr2JRyAxx8J3dBQjSc39V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ワークツリー作成時に未pushのローカルコミットが含まれるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imsugeno/dotfiles/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->