### PR TITLE
add: CLAUDE_CODE_PLUGIN_PREFER_HTTPS=1 で plugin の clone 経路を HTTPS に固定

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -38,6 +38,13 @@ let
       # 1h 書き込みは 5m の 2x コストだが、TTL 内に 2 回再ヒットすれば元が取れる前提で、
       # ユーザーが確認・思考する数分〜数十分のポーズを跨いでもキャッシュが生きる方が正味でメリットが大きい。
       ENABLE_PROMPT_CACHING_1H = "1";
+      # v2.1.143 で追加。GitHub から plugin を取得する際の clone を SSH ではなく HTTPS に固定する。
+      # `enabledPlugins` で `claude-plugins-official` 配下の typescript-lsp / pyright-lsp / gopls-lsp を
+      # 有効化しているため plugin 取得経路の信頼性は実害に直結する。SSH は ~/.ssh のキー設定・
+      # known_hosts・GitHub 側の鍵登録に依存し、新規マシンや CI / 一時環境では揃わない可能性がある。
+      # `DISABLE_UPDATES = "1"` で更新経路の真実の所在を Homebrew / GitHub Releases に固定したのと同じく、
+      # plugin 取得経路も環境差の少ない HTTPS に固定し、運用の予測可能性を高める defense-in-depth。
+      CLAUDE_CODE_PLUGIN_PREFER_HTTPS = "1";
     };
     # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr 双方の帰属表示を空文字列化して抑止する。
     attribution = {


### PR DESCRIPTION
## 背景: Claude Code v2.1.137 〜 v2.1.149 のアップデート概要

現在の `home-manager/programs/claude/default.nix` には v2.1.136 (`autoMode.hard_deny`) までの新機能が反映済み。それ以降のリリースを精査した。

### 主な追加

| バージョン | 追加内容 |
|---|---|
| v2.1.139 | `/goal`, `/scroll-speed` コマンド / hook の `args: string[]` exec form / `CLAUDE_PROJECT_DIR` を MCP stdio に伝播 |
| v2.1.141 | `terminalSequence` hook field / `ANTHROPIC_WORKSPACE_ID` / `CLAUDE_CODE_PLUGIN_PREFER_HTTPS` 初出 |
| v2.1.142 | Fast mode のデフォルトが Opus 4.7 に / `terminals` 設定 |
| v2.1.143 | `worktree.bgIsolation: "none"` / `CLAUDE_CODE_PLUGIN_PREFER_HTTPS` 正式版 / plugin dependency enforcement |
| v2.1.144 | `/resume` で background sessions も対象に / `/model` は session-only |
| v2.1.145 | `claude agents --json` / `skillOverrides` / `prUrlTemplate` / `CLAUDE_CODE_EFFORT_LEVEL` / `background_tasks`・`session_crons` を Stop/SubagentStop に追加 |
| v2.1.146 | `/code-review` (旧 `/simplify`) の effort パラメータ |
| v2.1.147 | `CLAUDE_CODE_SHELL_PREFIX` / `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` / Enterprise login 強制 |
| v2.1.148 | Bash exit 127 リグレッション修正 |
| v2.1.149 | `autoScrollEnabled` / `worktree.baseRef` / sandbox の書き込み許可範囲修正 / PowerShell `cd` のバイパス修正 / `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN` |

## 優先度判断

### 高 → 本PRで対応

- **v2.1.143 `CLAUDE_CODE_PLUGIN_PREFER_HTTPS = "1"`**
  - 既に `enabledPlugins` で `typescript-lsp@claude-plugins-official` / `pyright-lsp@claude-plugins-official` / `gopls-lsp@claude-plugins-official` を有効化している。plugin 取得経路の信頼性は LSP の有無に直結する実害。
  - SSH 経路は `~/.ssh` のキー設定・known_hosts・GitHub 側の鍵登録に依存し、新規マシンや一時環境では揃わない。
  - 既存の `DISABLE_UPDATES = "1"`（更新経路を Homebrew / GitHub Releases に固定）や `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = "1"`（クレデンシャル剥奪）と同じ defense-in-depth 思想に整合する。
  - 既存設定と衝突せず、副作用が小さく、得られる運用上の予測可能性が大きいため **高** と判断。

### 中 → 今回見送り

- **v2.1.149 `worktree.baseRef`**: 現状 `claude --worktree` を使用していないため不要。
- **v2.1.143 `worktree.bgIsolation: "none"`**: 同上。
- **v2.1.145 `skillOverrides`**: 現在の挙動を変える必要なし。スキルは `~/.config/claude/skills` の symlink で管理しており、上書き機構は使っていない。
- **v2.1.145 `CLAUDE_CODE_EFFORT_LEVEL`**: settings.json で既に `effortLevel = "xhigh"` を宣言的に設定済み。env での override は dotfiles の宣言性を弱める。
- **v2.1.141 `terminalSequence` hook field**: 既存の独自 `hooks/notify.ts` で macOS の通知を実装済み。置換するなら別 PR で慎重に検討。
- **v2.1.139 hook の `args: string[]` exec form**: 既存 hooks（`notify.ts`, `go-fmt.sh`）は機能しており、移行による得が小さい。

### 低 → 対応不要

- **v2.1.149 sandbox / PowerShell / Bash のセキュリティ修正**: バージョン更新で自動適用、設定変更不要。
- **v2.1.147 `/simplify` → `/code-review` リネーム**: slash command の体験差のみ、設定変更不要。
- **v2.1.149 `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN`, `autoScrollEnabled`**: UI 個人嗜好の範疇。
- **v2.1.147 `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`**: Stop hook 未使用。
- **v2.1.142 Fast mode の Opus 4.7 デフォルト化**: `CLAUDE_CODE_DISABLE_FAST_MODE = "1"` で Fast mode 自体を無効化済みのため無関係。
- **v2.1.141 `ANTHROPIC_WORKSPACE_ID`**: workload identity federation 用途、個人開発機では不要。

## 変更内容

`home-manager/programs/claude/default.nix` の `env` セクションに `CLAUDE_CODE_PLUGIN_PREFER_HTTPS = "1"` を追加。


---
_Generated by [Claude Code](https://claude.ai/code/session_01STiNAUGrNqeYWvEBjm8s8o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * GitHub からのプラグイン取得時に、より安全な HTTPS 接続を使用するようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imsugeno/dotfiles/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->