### PR TITLE
docs(claude): Opus 4.8 リリース対応で effortLevel / Fast Mode コメントを最新化

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -10,13 +10,20 @@ let
     showThinkingSummaries = true;
     autoMemoryEnabled = false;
     # v2.1.111 で Opus 4.7 向けに追加された `xhigh`（`high` と `max` の中間）。
-    # alwaysThinkingEnabled = true と合わせて、Opus 4.7 の推論深度を引き上げる。
+    # 当時の Opus 4.7 ではデフォルトが `xhigh` だったため設定値は default 維持の意味だったが、
+    # v2.1.154 で Opus 4.8 がリリースされて以降、`opus` alias (Anthropic API) は Opus 4.8 を指し、
+    # Opus 4.8 のデフォルト effort は `high` に下がっている（`xhigh` も引き続きサポート）。
+    # alwaysThinkingEnabled = true と合わせて、現行 Opus 4.8 のデフォルト `high` を明示的に
+    # 上書きし、推論深度を以前と同等以上に保つ。`xhigh` は session 跨ぎで永続する正規レベル。
     effortLevel = "xhigh";
     env = {
       # v2.1.36+ の Fast Mode（Opus 高速構成）を完全に無効化する。`/fast` コマンドも
-      # 「disabled by your organization」相当で弾かれる。Fast Mode は $30/$150 per MTok と
-      # 標準 Opus の倍以上のコストで、かつ additional usage に直接請求される（プラン枠を
-      # 消費しない）ため、誤って /fast を入力した際の事故的な高コスト発生を未然に防ぐ。
+      # 「disabled by your organization」相当で弾かれる。Fast Mode は additional usage に
+      # 直接請求される（プラン枠を消費しない）ため、誤って /fast を入力した際の事故的な
+      # 高コスト発生を未然に防ぐ。v2.1.154 で Opus 4.8 の Fast Mode は標準 Opus 比 2x rate
+      # × 2.5x speed に価格改定されたが、それでも追加課金経路であることに変わりはなく、
+      # かつ lean system prompt がデフォルト化された Opus 4.8 では通常モードでも十分速いため、
+      # 速度メリットに対してコスト経路を分けるリスクが見合わない。
       CLAUDE_CODE_DISABLE_FAST_MODE = "1";
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
       # v2.1.117 で外部ビルド向けに有効化。サブエージェントを fork して走らせることで


### PR DESCRIPTION
## 背景

Claude Code の `v2.1.143`（現在 dotfiles で言及されている最新バージョン）以降、`v2.1.163` までに以下の変更が入った。

### v2.1.144 - v2.1.163 の主なアップデート

| バージョン | 主な変更 |
|---|---|
| **v2.1.154** | **Opus 4.8 リリース**、`opus` alias が Opus 4.8 を指すように（Anthropic API）、Fast Mode 価格改定、lean system prompt がデフォルト化、`/simplify` が cleanup-only に変更 |
| v2.1.157 | `.claude/skills` の plugin 自動読み込み、`claude plugin init <name>` |
| v2.1.158 | Auto mode が Bedrock/Vertex/Foundry + Opus 4.7/4.8 で利用可能 (opt-in) |
| v2.1.160 | shell 起動ファイル/ビルド config 書き込み前の確認をデフォルト化 |
| v2.1.163 | `requiredMinimumVersion` / `requiredMaximumVersion` 管理設定、`/plugin list`、Hook の `additionalContext` 返却 |
| v2.1.152 | `MessageDisplay` hook event、`SessionStart.sessionTitle`、`/code-review --fix`、`/reload-skills` |
| v2.1.147 | `/simplify` → `/code-review` リネーム |

公式ドキュメント (`code.claude.com/docs/en/model-config`) から判明した重要事実：
- Opus 4.8 のデフォルト effort は `high`（Opus 4.7 は `xhigh`）
- Opus 4.8 / Opus 4.7 は `low, medium, high, xhigh, max` をサポート

## 優先度の判断

### 高（本PRで対応）

1. **`effortLevel = "xhigh"` のコメント実態の乖離**
   既存コメントは「v2.1.111 で Opus 4.7 向けに追加」「Opus 4.7 の推論深度を引き上げる」とあるが、これは Opus 4.7 が default の前提。v2.1.154 で `opus` alias が Opus 4.8 を指すようになって以降、Opus 4.8 のデフォルト effort は `high` に下がっているため、現状の `xhigh` 設定の意味は「default 維持」から「default 上書きで推論深度引き上げ」に変質している。設定の正当化根拠そのものに関わるため、コメントを実態に合わせる。

2. **`CLAUDE_CODE_DISABLE_FAST_MODE` の価格根拠の陳腐化**
   既存コメントは旧 Fast Mode 価格（`$30/$150 per MTok` = 標準 Opus の倍以上）を引いて Disable の正当化を書いているが、v2.1.154 で Opus 4.8 の Fast Mode は「標準 Opus 比 2x rate × 2.5x speed」に改定された。価格根拠の数字が事実と乖離しているため最新化する。主旨（additional usage への追加課金経路を遮断し、誤入力の事故を防ぐ）は維持。

### 中（本PRで見送り）

- **`requiredMinimumVersion` (v2.1.163)**: `DISABLE_UPDATES=1` の defense-in-depth として有効だが、新規マシン導入時に Homebrew 経由で古いバイナリが入った場合に起動拒否される副作用があり、保守コスト増。dotfiles を単一の真実の所在として固定する既存方針で十分カバーされており、設定追加の正味メリットが薄い。
- **`MessageDisplay` / `SessionStart.sessionTitle` Hook (v2.1.152)**: 既存の `Notification` / `PostToolUse` フック構成に組み込む用途が現状ない。
- **`worktree.bgIsolation` (v2.1.143)**: 既存の `worktree.baseRef = "head"` で意図する挙動は確保済み。

### 低（本PRで見送り）

- **`/code-review --fix` (v2.1.152)** / **`/reload-skills` (v2.1.152)** / **`/plugin list` (v2.1.163)**: 対話的に呼ぶ slash command で settings.json 反映が不要。
- **`/effort` ラベル変更（"Speed/Intelligence" → "Faster/Smarter"）**: UI 表示の変更のみ。
- **lean system prompt のデフォルト化**: 設定で無効化できる項目ではなく、Opus 4.8 の挙動として固定。

## 変更

- `home-manager/programs/claude/default.nix`: `effortLevel` と `CLAUDE_CODE_DISABLE_FAST_MODE` のコメントを Opus 4.8 リリース後の挙動・価格に合わせて更新。設定値は変更せず（既存値が Opus 4.8 でも引き続き有効かつ望ましい挙動を生むため）。

## テストプラン

- [ ] `make switch` で home-manager が settings.json を再生成し、`~/.config/claude/settings.json` の `effortLevel` / `env.CLAUDE_CODE_DISABLE_FAST_MODE` が変わっていないことを確認
- [ ] Claude Code 起動時に status line で effort level が `xhigh` 表示されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnERRJXjfPZ8DKqJjR2f2p)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 設定に関するコメントを最新の状況に合わせて更新し、説明内容を整理しました。

* **Chores**
  * 不要な説明文を削除し、コメントを簡潔に調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->