### PR TITLE
claude: fallbackModel 追加と Opus 4.8 への前提整合 (v2.1.144〜v2.1.168)

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -10,13 +10,24 @@ let
     showThinkingSummaries = true;
     autoMemoryEnabled = false;
     # v2.1.111 で Opus 4.7 向けに追加された `xhigh`（`high` と `max` の中間）。
-    # alwaysThinkingEnabled = true と合わせて、Opus 4.7 の推論深度を引き上げる。
+    # v2.1.154 で `opus` alias のデフォルト解決先が Opus 4.8 に切り替わり、4.8 のデフォルト
+    # effort は `high` になったため、xhigh を明示することで 4.8 でも一段深い推論を引き出す。
+    # xhigh は 4.7 / 4.8 双方でサポートされる。alwaysThinkingEnabled = true と合わせて
+    # 推論深度を引き上げる。
     effortLevel = "xhigh";
+    # v2.1.166 で追加。プライマリモデル (`opus` alias = Opus 4.8) が overloaded / 非リトライ可能な
+    # API エラーで利用不能になったとき、優先順に最大 3 つまでのフォールバック先を試す
+    # （ターンに対して 1 回リトライ）。v2.1.166 で `--fallback-model` が interactive session にも
+    # 適用されるようになったため、Agent Teams + xhigh + 1h cache の重い構成でピーク時に
+    # 4.8 が overloaded になっても対話を中断せず Sonnet 4.6 で継続できる。alias で記述することで
+    # 将来のモデル世代切替に追従する。
+    fallbackModel = [ "sonnet" ];
     env = {
       # v2.1.36+ の Fast Mode（Opus 高速構成）を完全に無効化する。`/fast` コマンドも
-      # 「disabled by your organization」相当で弾かれる。Fast Mode は $30/$150 per MTok と
-      # 標準 Opus の倍以上のコストで、かつ additional usage に直接請求される（プラン枠を
-      # 消費しない）ため、誤って /fast を入力した際の事故的な高コスト発生を未然に防ぐ。
+      # 「disabled by your organization」相当で弾かれる。v2.1.154 で Opus 4.8 の Fast Mode は
+      # 標準 Opus の 2x コスト / 2.5x スピードへ引き下げられたが、依然として標準より高コストで
+      # additional usage に直接請求される（プラン枠を消費しない）。誤って /fast を入力した際の
+      # 事故的な高コスト発生を未然に防ぐ意図は維持。
       CLAUDE_CODE_DISABLE_FAST_MODE = "1";
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
       # v2.1.117 で外部ビルド向けに有効化。サブエージェントを fork して走らせることで
@@ -33,8 +44,8 @@ let
       # 並行インストールが生まれてバージョンの真実の所在が二重化する。dotfiles を単一の真実の所在として固定する。
       DISABLE_UPDATES = "1";
       # v2.1.108 で追加・v2.1.128 で正式対応。プロンプトキャッシュ TTL を 5 分 → 1 時間に延長する。
-      # Opus 4.7 + effortLevel = "xhigh" + AGENT_TEAMS / FORK_SUBAGENT という重い構成では、
-      # 拡張思考や並列サブエージェントが走る間に 5 分の TTL を簡単に超え、再書き込みコストが嵩む。
+      # Opus 4.8 (`opus` alias デフォルト) + effortLevel = "xhigh" + AGENT_TEAMS / FORK_SUBAGENT
+      # という重い構成では、拡張思考や並列サブエージェントが走る間に 5 分の TTL を簡単に超え、再書き込みコストが嵩む。
       # 1h 書き込みは 5m の 2x コストだが、TTL 内に 2 回再ヒットすれば元が取れる前提で、
       # ユーザーが確認・思考する数分〜数十分のポーズを跨いでもキャッシュが生きる方が正味でメリットが大きい。
       ENABLE_PROMPT_CACHING_1H = "1";


### PR DESCRIPTION
## アップデート概要 (v2.1.144 → v2.1.168)

前回トラッキング済みの v2.1.143 以降、ユーザー設定に影響しうる主要アップデート:

| バージョン | 主要変更 |
|---|---|
| 2.1.154 | **Opus 4.8 リリース。`opus` alias のデフォルト解決先が 4.7 → 4.8 に切替。4.8 のデフォルト effort は `high`、Fast Mode が 2x コスト / 2.5x スピードに引き下げ。Lean system prompt が 4.8 以降のデフォルト** |
| 2.1.157 | `.claude/skills` 内 plugin の auto-load、`claude plugin init`、settings.json の `agent` field、`EnterWorktree` で切替 |
| 2.1.158 | `CLAUDE_CODE_ENABLE_AUTO_MODE=1` で Bedrock/Vertex/Foundry の auto mode 解禁 |
| 2.1.160 | shell startup files (`.zshenv`, `.zlogin` 等) への書き込みプロンプト、`acceptEdits` でビルドツール設定への書き込み確認 |
| 2.1.161 | `OTEL_RESOURCE_ATTRIBUTES` → metric label、parallel Bash 失敗が他をキャンセルしない |
| 2.1.162 | `claude agents --json` の `waitingFor`、Remote Control が footer pill に |
| 2.1.163 | `requiredMinimumVersion`/`requiredMaximumVersion` (managed 専用)、`/plugin list`、`Stop`/`SubagentStop` で `hookSpecificOutput.additionalContext` |
| 2.1.166 | **`fallbackModel` 設定 (最大 3 つの順序付きフォールバック先)、deny rule の tool-name 位置で glob、`--fallback-model` が interactive session にも適用、`MAX_THINKING_TOKENS=0` で thinking 無効化** |
| 2.1.152 | `MessageDisplay` hook、`SessionStart` で `sessionTitle`/`reloadSkills`、`/code-review --fix`、`pluginSuggestionMarketplaces` (managed) |

## 優先度判定

### 高 (本 PR で対応)

- **Opus 4.8 リリースへの前提整合 (v2.1.154)**: 設定値はすべて 4.8 でも有効だが、既存コメントが「Opus 4.7」「Fast Mode は標準 Opus の倍以上のコスト」を前提にしており、現状 (4.8 デフォルト、Fast Mode 2x コスト) と乖離している。dotfiles はコメント駆動で意図を残す方針のため、整合性確保を優先する。
- **`fallbackModel` 追加 (v2.1.166)**: Agent Teams + `effortLevel = "xhigh"` + `ENABLE_PROMPT_CACHING_1H` の重い構成は、ピーク時に Opus 4.8 overloaded を踏みやすい。v2.1.166 で `--fallback-model` が interactive session にも適用されたため、対話中断回避の実利が大きい。CHANGELOG に「up to three fallback models tried in order」と明記されているため配列形式 `[ "sonnet" ]` で記述し、alias 経由で将来のモデル世代切替に追従する。

### 中 (本 PR では入れない)

- `requiredMinimumVersion` (v2.1.163): managed settings 専用とドキュメントで明記されており、個人ユーザー settings では効かない可能性が高い。チーム展開時に再評価。
- `MessageDisplay` hook / `SessionStart` の `sessionTitle` (v2.1.152): 現状の hooks (`notify.ts`, `go-fmt.sh`) のユースケースに該当しない。必要なユースケースが出てから追加。
- `agent` field in `settings.json` (v2.1.157): subagent をプリ定義する運用に切り替えるなら有用だが、現状未使用。

### 低

- ビルトイン skill 追加 (`/code-review`, `/simplify` 等): 設定不要、`claude` 本体に同梱。
- Windows / Linux 固有の bug fix: macOS aarch64 単一運用のため影響なし。
- enterprise 専用設定 (`allowAllClaudeAiMcps` 等): 対象外。
- 大半の bug fix: `DISABLE_UPDATES=1` で内部 autoupdater は塞いでいるが、Homebrew 経由のバージョン昇格で揃う。

## 変更内容

`home-manager/programs/claude/default.nix`:

1. `fallbackModel = [ "sonnet" ]` を `baseSettings` に追加 (v2.1.166)。
2. `effortLevel = "xhigh"` のコメントを、`xhigh` が Opus 4.7 / 4.8 双方で有効である事実と、4.8 のデフォルト effort が `high` であるため明示する意義に書き換え。
3. `CLAUDE_CODE_DISABLE_FAST_MODE` のコメントを、v2.1.154 の Fast Mode 価格改定 (2x コスト / 2.5x スピード) を反映しつつ、disable の意図 (additional usage で誤爆防止) を維持。
4. `ENABLE_PROMPT_CACHING_1H` のコメントから「Opus 4.7」を除去し、「Opus 4.8 (`opus` alias デフォルト)」へ更新。

設定値の追加は `fallbackModel` のみ。それ以外はコメント整合のみで挙動変化なし。

---
_Generated by [Claude Code](https://claude.ai/code/session_011ssfzZUZ6oDuywVUxGCSma)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Claude設定の説明コメントを更新しました。Opusモデルの世代情報やキャッシング機能、推論動作に関する記述が改善されています。実際の設定値に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->