### PR TITLE
feat(claude): security-guidance plugin を有効化、v2.1.150+ の事実反映

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -10,13 +10,16 @@ let
     showThinkingSummaries = true;
     autoMemoryEnabled = false;
     # v2.1.111 で Opus 4.7 向けに追加された `xhigh`（`high` と `max` の中間）。
-    # alwaysThinkingEnabled = true と合わせて、Opus 4.7 の推論深度を引き上げる。
+    # v2.1.154 で Opus 4.8 がデフォルトモデルになった後も同レベル指定は有効で、
+    # Opus 4.8 の推奨デフォルト `high` を一段引き上げる位置づけ。
+    # alwaysThinkingEnabled = true と合わせて推論深度を最大化する。
     effortLevel = "xhigh";
     env = {
       # v2.1.36+ の Fast Mode（Opus 高速構成）を完全に無効化する。`/fast` コマンドも
-      # 「disabled by your organization」相当で弾かれる。Fast Mode は $30/$150 per MTok と
-      # 標準 Opus の倍以上のコストで、かつ additional usage に直接請求される（プラン枠を
-      # 消費しない）ため、誤って /fast を入力した際の事故的な高コスト発生を未然に防ぐ。
+      # 「disabled by your organization」相当で弾かれる。v2.1.150 でデフォルトが Opus 4.8 に
+      # 切り替わり、4.8 fast は $10/$50 per MTok（標準の 2x で約 2.5x の速度）、4.7 / 4.6 は
+      # $30/$150 のまま。いずれにせよ additional usage に直接請求されプラン枠を消費しないため、
+      # 誤って /fast を入力した際の事故的な高コスト発生を未然に防ぐ。
       CLAUDE_CODE_DISABLE_FAST_MODE = "1";
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
       # v2.1.117 で外部ビルド向けに有効化。サブエージェントを fork して走らせることで
@@ -55,6 +58,14 @@ let
       "typescript-lsp@claude-plugins-official" = true;
       "pyright-lsp@claude-plugins-official" = true;
       "gopls-lsp@claude-plugins-official" = true;
+      # v2.1.154 で公開された脆弱性レビュー plugin。各 Edit/Write 直後の高速パターンチェック、
+      # 各ターン終了時のモデルレビュー、commit / push 時の agentic deep review の三段で
+      # Claude 自身が書いた変更の脆弱性を検出・修正する。
+      # `permissions.deny` / `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` / `autoMode.hard_deny` で
+      # secrets 露出・危険コマンド層の防衛を組んでいるのに対し、コード品質側
+      # （SQLi / XSS / 認証バグ等）のレイヤを追加する defense-in-depth。
+      # プロジェクト固有ルールは `.claude/claude-security-guidance.md` に置く。
+      "security-guidance@claude-plugins-official" = true;
     };
     # v2.1.133 で追加・v2.1.143 でデフォルトが "head" → "fresh" (origin/<default>) に変更された。
     # Agent tool の `isolation: "worktree"` / `--worktree` / `EnterWorktree` 起動時、


### PR DESCRIPTION
## 経緯

Claude Code の v2.1.143 以降（直近 1 ヶ月）に公開された変更を release note と What's new digest で洗い出し、現状の `home-manager/programs/claude/default.nix` への反映価値を高 / 中 / 低で判定したうえで、**高** の項目のみ取り込んだ。

## 検出したアップデート一覧

### Week 21（v2.1.143 → v2.1.149, May 18–22）

- Auto mode が Pro plan / Sonnet 4.6 でも利用可能に
- `/usage` がプラン上限の内訳を skill / subagent / plugin / MCP server 単位で表示
- `/code-review` コマンド追加（`--comment` で GitHub PR にインラインコメント投稿）
- background sessions が `/resume` に並ぶ、`Ctrl+T` で pin して idle 時も alive
- `worktree.bgIsolation: "none"` 設定追加
- `/extra-usage` → `/usage-credits` リネーム

### Week 22（v2.1.150 → v2.1.157, May 25–29）

- **Claude Opus 4.8** が新デフォルト（Max / Team Premium / Enterprise PAYG / Anthropic API）、`/effort xhigh` で hardest tasks
- **Dynamic workflows**（research preview）：Claude が書いたオーケストレーションスクリプトを多数の subagent に展開、`/workflows` で管理
- **security-guidance plugin**：Claude の編集に対し三段（pattern check → model review → agentic deep review）で脆弱性検出
- Fast mode のデフォルトが Opus 4.8 に移行、$10/$50 per MTok（4.7 / 4.6 は $30/$150 据え置き）
- `--fallback-model` がセッション継続をブロックしなくなった
- `MessageDisplay` hook event 追加
- skills / commands frontmatter で `disallowed-tools` 指定可
- `.claude/skills` 配下の plugin が marketplace なしで自動ロード
- plugin `defaultEnabled: false` 指定で「インストール済み・無効」状態を作れる

### v2.1.158 以降

- バグ修正 / 信頼性向上中心、設定面での新規変更なし

## 優先度判定

### 高（本 PR で対応）

1. **`security-guidance` plugin の有効化**
   既存の `permissions.deny` / `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` / `autoMode.hard_deny` で secrets 露出と危険コマンドの 2 層を組んでいるが、Claude が書いた SQLi / XSS / 認証バグ等のコード品質側は素通し。`claude-plugins-official` から install できる公式 plugin で、思想・配布元ともに既存構成と完全に揃う defense-in-depth。`enabledPlugins` への追加のみで完結。

2. **Fast Mode 無効化コメントの更新**
   v2.1.150 で fast mode のデフォルトが Opus 4.8 に移り価格が $30/$150 → $10/$50（標準の 2x、約 2.5x 速度）に変わったため、現状のコメント「$30/$150 per MTok と標準 Opus の倍以上のコスト」は事実と乖離している。判断根拠が古い情報を抱えたままだと将来の見直し時にバイアスがかかるため、現価格と「いずれにせよ additional usage 直請求」という設定維持理由を明示する形に書き直した。設定値 `CLAUDE_CODE_DISABLE_FAST_MODE = "1"` 自体は維持。

3. **`effortLevel = "xhigh"` のコメント更新**
   v2.1.111 の Opus 4.7 専用記述だったが、v2.1.154 で Opus 4.8 がデフォルトモデルとなった後も同設定は有効。Opus 4.8 の推奨デフォルト `high` を一段引き上げる位置づけに記述を更新した。

### 中（見送り）

- **Dynamic workflows / `ultracode`**：既に `effortLevel = "xhigh"` + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` + `CLAUDE_CODE_FORK_SUBAGENT` で重い構成を明示的に固めている。`ultracode` は workflow 起動を Claude 側に判定させるため予測可能性が落ち、現運用方針（明示固定で挙動を再現可能に保つ）と噛み合わない。
- **`worktree.bgIsolation`**：background sessions を常用する運用になってから検討。

### 低（見送り）

- `/code-review`、`/usage`、`MessageDisplay` hook、`--fallback-model` の挙動改善などは設定不要で自動利用可能、または現運用に直接の関連薄。

## 補足

`enabledPlugins` への追記は settings.json への記述で、初回起動時に `claude-plugins-official` marketplace から install される（既設の typescript-lsp / pyright-lsp / gopls-lsp と同じ経路）。`.claude/claude-security-guidance.md` でプロジェクト固有ルールを追加できるが、本リポジトリにはまず置かない判断（必要に応じて後追い）。


---
_Generated by [Claude Code](https://claude.ai/code/session_0169Ltsg2a2iKb96mAPK1DVf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * セキュリティ検証プラグインを追加しました。コード編集時、ターン終了時、コミット・プッシュ時に複数段階での脆弱性検出と修正を実施します。

* **ドキュメンテーション**
  * 設定に関するコメントをバージョン情報に合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->