### PR TITLE
claude: fallbackModel に Sonnet 4.6 を設定

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -12,6 +12,11 @@ let
     # v2.1.111 で Opus 4.7 向けに追加された `xhigh`（`high` と `max` の中間）。
     # alwaysThinkingEnabled = true と合わせて、Opus 4.7 の推論深度を引き上げる。
     effortLevel = "xhigh";
+    # v2.1.166 で追加。プライマリ（Opus 4.7 + effortLevel = "xhigh"）が unavailable / rate-limited な
+    # 状況での自動フォールバック先。AGENT_TEAMS / FORK_SUBAGENT を有効化した重い構成では並列
+    # リクエストが集中して rate limit を踏みやすく、fallback を持たないとセッション自体が停止する。
+    # 品質階層が最も近い Sonnet 4.6 を選択（Haiku は速度寄りで深い思考タスクには不向き）。
+    fallbackModel = "claude-sonnet-4-6";
     env = {
       # v2.1.36+ の Fast Mode（Opus 高速構成）を完全に無効化する。`/fast` コマンドも
       # 「disabled by your organization」相当で弾かれる。Fast Mode は $30/$150 per MTok と


### PR DESCRIPTION
## 背景

dotfiles の Claude Code 設定は v2.1.143 までの変更を取り込み済みだったため、それ以降の最新版（v2.1.169）までのリリースノートとドキュメントを確認し、反映の要否を優先度で判断した。

## v2.1.144 〜 v2.1.169 のアップデート分類

| 機能 | バージョン | 優先度 | 判定理由 |
|---|---|---|---|
| `fallbackModel` | v2.1.166 | **高** | primary 不可用時に自動フォールバック。重い構成の運用継続性に直結 |
| `disableBundledSkills` | v2.1.169 | 低 | dotfiles 一元管理思想とは合致するが、bundled に `/code-review` `/verify` `/init` 等の実用 skill が含まれるため無効化のデメリットが大きい |
| `requiredMinimumVersion` / `requiredMaximumVersion` | v2.1.163 | 対象外 | scope が Managed のみ。User settings では設定不可 |
| `CLAUDE_CODE_SAFE_MODE` / `--safe-mode` | v2.1.169 | 低 | troubleshooting 用。常時有効化は customization 無効化と衝突 |
| `/cd` コマンド | v2.1.169 | 低 | 利便性向上のみ、設定変更不要 |
| Opus 4.8 / Fast mode (v2.1.154) | v2.1.154 | 低 | 既に Opus 4.7 を明示固定し Fast mode は `CLAUDE_CODE_DISABLE_FAST_MODE=1` で塞いでいる選択を維持 |
| deny rule の glob pattern | v2.1.166 | 低 | 既存の prefix ベース deny rule で十分機能 |
| Auto mode opt-in 廃止 | v2.1.151 | 低 | 既に auto mode 利用中 |
| `MAX_THINKING_TOKENS=0` | v2.1.166 | 低 | `alwaysThinkingEnabled = true` を採用しているため不要 |
| `pluginSuggestionMarketplaces` | v2.1.151 | 低 | enterprise 向けの管理ポリシー |

## 高優先度として反映する内容

`fallbackModel = "claude-sonnet-4-6"` を `baseSettings` に追加。

### なぜ「高」優先度か

- 現状の構成は `Opus 4.7 + effortLevel = "xhigh" + alwaysThinkingEnabled = true + CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 + CLAUDE_CODE_FORK_SUBAGENT=1` で、サブエージェント並列実行が前提。並列リクエストが集中すると Opus 4.7 の rate limit を踏みやすい。
- 設定前は primary が unavailable / rate-limited な瞬間にセッションが停止する。これは「重い構成を回す」という運用方針と直接衝突する。
- fallback を握っておけば停止せず継続でき、コストは fallback 発火時のみ発生する。defense-in-depth 思想（`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` や `autoMode.hard_deny` と同じ）と合致。

### なぜ Sonnet 4.6 を選択したか

- Opus 4.7 が落ちた瞬間も「思考の深さ」が求められるタスク中である可能性が高いため、品質階層が最も近い Sonnet 4.6 が妥当。
- Haiku 4.5 は速度寄りで `effortLevel = "xhigh"` 相当の深い推論には不向き。

## その他の判断について

- `disableBundledSkills` は当初 HIGH 候補だったが、bundled に含まれる `/code-review` `/verify` `/init` 等の汎用 skill は dotfiles の独自 skill（`git-*`, `pr-spec`, `daily-report` 等）と機能領域が重複しないため、無効化するとユーザー体験が劣化する。dotfiles 一元管理メリットよりデメリットが大きいと判断し見送り。
- `requiredMinimumVersion` は最低バージョン保証として有用だが Managed scope 限定のため User settings では宣言不可。dotfiles では対応不可。



---
_Generated by [Claude Code](https://claude.ai/code/session_01NvmgYFLAncGckSQsQFDLe2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能改善**
  * プライマリモデルが利用できない場合に、代替モデルを自動的に使用する設定が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->