### PR TITLE
chore: nixpkgs / nix-darwin / home-manager を 26.05 に更新

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,13 @@
   description = "imsugeno's dotfiles and nix-darwin configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     nix-darwin = {
-      url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
+      url = "github:nix-darwin/nix-darwin/nix-darwin-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.11";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
## 概要

`flake.nix` の 3 つの input（nixpkgs / nix-darwin / home-manager）を 25.11 系から 26.05 系へ更新する。`flake.lock` の再生成は手元で `make update`（= `nix flake update`）を実行して反映する想定。

## 何が更新されたか

### NixOS / nixpkgs 26.05 "Yarara"（2026-05-30 リリース）

- 新規 20,442 パッケージ追加 / 既存 20,641 更新 / 17,532 削除
- ツールチェーン: GCC 14 → 15、Node.js 22 LTS → 24 LTS
- NixOS モジュール 85 新規 / 1,547 オプション追加（本リポジトリは nix-darwin なので NixOS モジュール差分の直接の影響はない）
- Stage 1 が systemd ベースに（NixOS 専用、darwin には影響なし）
- **x86_64-darwin はこの 26.05 が最後のサポート対象**。本リポジトリは `aarch64-darwin` 固定（`nix-darwin/default.nix:16`、`flake.nix:18`）なので影響なし。
- 25.11 "Xantusia" は deprecated 扱いとなり、セキュリティ更新は **2026-06-30 で停止**。

### nix-darwin / home-manager

- `nix-darwin-26.05` および `home-manager release-26.05` ブランチがそれぞれ用意済み（直近も継続的にメンテされている）。
- 25.11 → 26.05 の本体 module API に破壊的変更があった場合は `make check`（= `nix flake check`）と `darwin-rebuild build` の段階で検出されるため、`make rebuild` 前に `make check` を回して差分を見るのが安全。

## 優先度判定

| 優先度 | 項目 | 判断理由 |
|--|--|--|
| **高** | **nixpkgs/nix-darwin/home-manager 25.11 → 26.05** | 25.11 のサポート終了が **2026-06-30**（本 PR 作成時点の 13 日後）。EOL を跨ぐとセキュリティ更新が止まり、それ以降の上流 CVE 修正が降りてこなくなる。期日が固定で、かつ受動的に解消されないため高。本 PR で対応。 |
| 中 | Claude Code v2.1.143 → v2.1.179 の設定キー追加（`fallbackModel`、permissions の `Tool(param:value)` 構文、`MessageDisplay` フック、`worktree.bgIsolation` 等） | 既存設定（`alwaysThinkingEnabled` / `effortLevel = "xhigh"` / `autoMode.hard_deny` / `worktree.baseRef = "head"` 等）はいずれも現行版で引き続き有効。新キーは「使えば便利」のレイヤで、サポート終了のような期限はない。利用判断には個別の意図設計が要るため、本 PR では扱わず別途検討する方が分離度が良い。 |
| 低 | Claude Code 側の UI 修正・スクロール挙動・`/doctor` 再設計などのバグ修正系 | 設定差分なし。Claude Code 本体（Homebrew cask `claude-code` および `scripts/install-claude-code.sh` 経由の `~/.local/bin/claude`）の更新で自動的に反映されるため、dotfiles 側で追従するものがない。 |

ここで「高」に当たるのは nixpkgs 系のみなので、本 PR ではそれだけを変更する。

## 適用手順

1. このブランチをマージ後、ローカルで:
   ```sh
   make update    # flake.lock を 26.05 系で再生成
   make check     # 念のため flake 全体の整合性チェック
   make rebuild   # update + mcp + switch（実機反映）
   ```
2. 26.05 で削除/改名されたパッケージがあれば `make check` か `make rebuild` のビルド時にエラーで出る。具体的な影響箇所は出てから対処（前倒しの推測修正は入れない）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaiKaQ1tAudtkGzEzCBsvq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発環境の依存関係バージョンを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->