### PR TITLE
chore(claude): attribution.sessionUrl で session link を抑止

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -46,10 +46,14 @@ let
       # plugin 取得経路も環境差の少ない HTTPS に固定し、運用の予測可能性を高める defense-in-depth。
       CLAUDE_CODE_PLUGIN_PREFER_HTTPS = "1";
     };
-    # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr 双方の帰属表示を空文字列化して抑止する。
+    # `includeCoAuthoredBy` は deprecated。attribution 設定で帰属表示を空文字列化して抑止する。
+    # v2.1.183 で `sessionUrl` が追加。commit / PR 末尾に Claude Code が挿入する
+    # `Claude-Session: https://claude.ai/code/session_*` トレイラーも空文字列化し、
+    # commit / pr で Co-Authored-By を消しているのと同じ delete-by-default に揃える。
     attribution = {
       commit = "";
       pr = "";
+      sessionUrl = "";
     };
     enabledPlugins = {
       "typescript-lsp@claude-plugins-official" = true;


### PR DESCRIPTION
## アップデート調査の経緯

定期ジョブで Claude Code の release notes（公式 CHANGELOG.md）と settings docs を `v2.1.143`（既存設定で参照済みの最新版）以降について確認。`v2.1.144` ～ `v2.1.183` の中で dotfiles に取り込み価値のある変更は以下。

### High（本 PR で対応）

- **`attribution.sessionUrl`（v2.1.183）**: commit / PR 末尾に Claude Code が挿入する `Claude-Session: https://claude.ai/code/session_*` トレイラーを抑止する設定。

### Medium（本 PR では対応しない）

- **`fallbackModel`（v2.1.166）**: Opus 過負荷時に最大 3 モデルまでフォールバック。現状の `effortLevel = "xhigh"` + Opus 4.7 構成は重く API 拒否時の影響は大きいが、フォールバック先の挙動（軽量モデルでの拡張思考なし運用）が許容できるか別途検討したい。
- **`disableBundledSkills`（v2.1.169）**: bundled skills / workflows を model から隠す。`skills-lock.json` でカリキュレートしている user skill と bundled skill が共存可能なため、強制的に隠す必然性が薄い。
- **deny rule の glob 拡張（v2.1.166）**: `"*"` で全 deny 等が可能に。現行 deny rule（`Bash(git push*)` 等）は機能しており、強化案は別途。

### Low（不採用）

- `--safe-mode` / `CLAUDE_CODE_SAFE_MODE`（v2.1.169 / トラブルシューティング用、常時設定するものではない）
- Opus 4.8 default（v2.1.154 / 当環境は Opus 4.7 固定で `effortLevel = "xhigh"` は既に Opus 4.7 / 4.8 双方の推奨値）
- `MAX_THINKING_TOKENS=0`（v2.1.166 / `alwaysThinkingEnabled = true` の意図に反する）
- `wheelScrollAccelerationEnabled` / `footerLinksRegexes` / `sandbox.allowAppleEvents` 等の UI / sandbox 系（個人嗜好または当環境で未利用）
- auto mode の destructive git block 強化（v2.1.183 / 設定不要、自動適用）

## なぜ High と判断したか

既存設定で `attribution.commit = ""` / `attribution.pr = ""` を明示的に空文字列化し、Co-Authored-By トレイラーを delete-by-default としている。一方で commit / PR 末尾に挿入される `Claude-Session:` URL は別フィールド扱いで、これまで抑止する手段がなかった（issue #41873 が「not planned」で closed されていたが v2.1.183 で実装された）。

`sessionUrl` 未設定の状態は、ユーザーの「artifact に Claude 由来のメタデータを残さない」という方針が片肺で、Co-Authored-By だけ消えて session URL は残るという中途半端な状態になっている。同じ意図のフィールドが追加された以上、設定の整合性を取るのは即時対応すべき。

差分も `attribution` ブロックに 1 行追加するだけで、リスクと作業コストはほぼゼロ。

## 変更点

`home-manager/programs/claude/default.nix` の `attribution` ブロックに `sessionUrl = ""` を追加し、commit / pr と同じく空文字列化。

## 検証

- [ ] `make switch` で apply 後、新規 commit / PR に `Claude-Session:` トレイラーが含まれないことを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01QpJNumnRpAYMJxRUB8LA1M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 設定変更

* **設定更新**
  * Claude のアトリビューション設定を更新しました。セッション情報などの帰属表示がデフォルトで抑止されるように変更され、プライバシー設定がより厳格になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->