### PR TITLE
chore: claude-code v2.1.183 の attribution.sessionUrl を追加

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -46,10 +46,16 @@ let
       # plugin 取得経路も環境差の少ない HTTPS に固定し、運用の予測可能性を高める defense-in-depth。
       CLAUDE_CODE_PLUGIN_PREFER_HTTPS = "1";
     };
-    # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr 双方の帰属表示を空文字列化して抑止する。
+    # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr / sessionUrl の帰属表示を空文字列化して抑止する。
+    # `sessionUrl` は v2.1.183 で追加。web / Remote Control セッション（Claude Code on the web、
+    # スケジュール routine 等）で commit / PR の trailer に追記される `claude.ai/code/session_*` URL を抑止する。
+    # `commit = ""` は Co-Authored-By を消すが session URL は別 trailer 行で扱われるため別途設定が必要。
+    # session URL は社外提出物に内部セッション ID を漏洩させ得るため、既存の `commit` / `pr` 抑止と同じ
+    # defense-in-depth でこの経路も塞ぐ。
     attribution = {
       commit = "";
       pr = "";
+      sessionUrl = "";
     };
     enabledPlugins = {
       "typescript-lsp@claude-plugins-official" = true;


### PR DESCRIPTION
## アップデート調査の対象

Claude Code v2.1.143 → v2.1.185（最新）の差分を release notes と公式ドキュメントで確認し、本 dotfiles に反映すべき項目を抽出した。

## 主なアップデート（抜粋）

| バージョン | 内容 |
|---|---|
| v2.1.183 | `attribution.sessionUrl` 追加 / auto mode の破壊的 git 操作の既定ガード強化 / `/config --help` |
| v2.1.181 | `sandbox.allowAppleEvents` / `CLAUDE_CLIENT_PRESENCE_FILE` / `/config key=value` |
| v2.1.178 | `Tool(param:value)` パーミッション構文 / Agent Teams の implicit team 化 |
| v2.1.176 | `language` がセッションタイトル生成にも作用 / `footerLinksRegexes` |
| v2.1.174 | `wheelScrollAccelerationEnabled` |
| v2.1.172 | サブエージェントの 5 階層ネスト対応 |
| v2.1.170 | Fable 5 リリース |
| v2.1.169 | `--safe-mode` / `/cd` / `disableBundledSkills` / `post-session` フック |
| v2.1.166 | `fallbackModel` / deny ルールへの glob 対応 |
| v2.1.163 | `requiredMinimumVersion` / `requiredMaximumVersion` |
| v2.1.154 | Opus 4.8 / `/workflows` |

## 優先度判断

### High（反映する）
- **`attribution.sessionUrl = ""`（v2.1.183）**
  - 本リポジトリは web / スケジュール routine 経由で動かす運用で、現状 `attribution.commit = ""` / `pr = ""` で Co-Authored-By trailer は抑止済みだが、session URL は別 trailer 行のため未抑止。
  - session URL は社外提出物（OSS リポジトリへの PR 等）に内部セッション ID を漏洩させ得るので、既存の commit / pr 抑止と同じ defense-in-depth の意図でこの経路も塞ぐ必要がある。
  - 既存 attribution ブロックへの 1 行追加で済み副作用も限定的。

### Medium / Low（反映しない）
- **Opus 4.8 / Fable 5 への切り替え**: 現状の `effortLevel = "xhigh"` は Opus 4.7 専用で、明示的に 4.7 に固定する設計意図が `default.nix` のコメントに残っている。モデル切替は別 PR で扱うべき範囲。
- **`disableBundledSkills`（v2.1.169）**: bundled の artifact-design / deep-research / code-review 等を実用しているため有効維持。skill のソース管理を GitHub fetch に寄せた変更（113cd58）はユーザー定義 skill の話で、bundled とは別物。
- **`fallbackModel`（v2.1.166）**: Opus 固定の方針と矛盾するため不要。
- **auto mode の破壊的 git ガード強化（v2.1.183）**: 既定値の引き締めで設定変更不要。既存の `Bash(git push*)` deny / `autoMode.hard_deny` と整合。
- **`--safe-mode` / `/cd` / `Tool(param:value)` / `wheelScrollAccelerationEnabled` / `footerLinksRegexes`**: 現運用で必要性なし。

## 変更内容

`home-manager/programs/claude/default.nix` の `attribution` ブロックに `sessionUrl = ""` を追加し、追加理由と既存の `commit` / `pr` 抑止との関係をコメントで残した。

## 検証

- 本環境に nix CLI が無いため `make check` は手元未実施。
- 反映時は `make switch` で `~/.config/claude/settings.json` に `"attribution": { "commit": "", "pr": "", "sessionUrl": "" }` が書き込まれることを確認のこと。


---
_Generated by [Claude Code](https://claude.ai/code/session_01At3RBxiwy1u6Kxk7GAj5iG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * アトリビューション設定においてセッションURLの非表示処理が追加されました。これにより、特定のセッション由来のURLがコンテンツから除外されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->