### PR TITLE
chore: attribution.sessionUrl = false で claude.ai セッションリンクを抑止

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -46,10 +46,15 @@ let
       # plugin 取得経路も環境差の少ない HTTPS に固定し、運用の予測可能性を高める defense-in-depth。
       CLAUDE_CODE_PLUGIN_PREFER_HTTPS = "1";
     };
-    # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr 双方の帰属表示を空文字列化して抑止する。
+    # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr の帰属表示を空文字列化して抑止する。
+    # v2.1.183 で追加された `sessionUrl` を false にし、claude.ai のセッションリンク
+    # （commit message 末尾の `Claude-Session: https://claude.ai/code/session_...` 行）も同時に抑止する。
+    # `commit = ""` / `pr = ""` のみではセッション URL は別経路で付与されるため、帰属抑止を完結させるには
+    # この設定が必要。Issue #41873 / #66504 で報告された挙動への正式な対応設定。
     attribution = {
       commit = "";
       pr = "";
+      sessionUrl = false;
     };
     enabledPlugins = {
       "typescript-lsp@claude-plugins-official" = true;


### PR DESCRIPTION
## アップデート内容の把握

v2.1.143（前回反映済みバージョン）から最新 v2.1.185 までの Claude Code リリースノートを確認した。主な変更は以下の通り。

| バージョン | 主な変更 |
|---|---|
| v2.1.185 | stream-stall ヒントのタイミング調整（10s → 20s） |
| v2.1.183 | **`attribution.sessionUrl` 追加**・auto mode で破壊的 git/terraform 操作を明示要求時のみに制限・deprecated モデル警告 |
| v2.1.181 | `/config key=value` 構文・`sandbox.allowAppleEvents`・`CLAUDE_CLIENT_PRESENCE_FILE` |
| v2.1.178 | エージェントチーム再構築（`TeamCreate`/`TeamDelete` 削除）・`Tool(param:value)` 権限構文 |
| v2.1.176 | セッションタイトルが会話言語で生成 |
| v2.1.175 | `enforceAvailableModels`（managed setting） |
| v2.1.172 | サブエージェントのネスト深度 5 まで対応 |
| v2.1.170 | Fable 5 GA |
| v2.1.169 | `post-session` フック・`--safe-mode`・`/cd`・`disableBundledSkills` |
| v2.1.166 | `fallbackModel`（最大 3 つ）・deny rule での glob 対応 |
| v2.1.163 | `requiredMinimumVersion` / `requiredMaximumVersion`（managed） |
| v2.1.160 | shell startup ファイル書き込み時に prompt（破壊的変更） |
| v2.1.158 | Bedrock / Vertex / Foundry でも auto mode 利用可（opt-in） |
| v2.1.154 | Opus 4.8 デフォルト化・`/effort xhigh` 利用可・dynamic workflows・lean system prompt・`/chrome` |
| v2.1.152 | `MessageDisplay` フック・`/reload-skills`・`pluginSuggestionMarketplaces` |
| v2.1.144 | `/model` が現セッション限定の挙動に変更（破壊的） |

## 優先度判断

| 候補 | 優先度 | 判断理由 |
|---|---|---|
| `attribution.sessionUrl = false` | **高** | 既存 `attribution.commit = ""` / `pr = ""` は commit message 末尾の `Claude-Session: https://claude.ai/code/session_...` を抑止できない（別経路で付与される）。本リポジトリは AI 帰属抑止を一貫した方針として宣言済みのため、これを完結させる |
| `CLAUDE_CLIENT_PRESENCE_FILE` | 中 | Notification フックでモバイル通知を送る運用と整合するが、プレゼンス検知ロジックを別途実装する必要があり、即時の困りごとは発生していない |
| `fallbackModel` | 中 | Opus 系不通時の保険として有用だが、現状トリガーとなる障害は未観測 |
| `Tool(param:value)` 権限構文 | 中 | 既存 deny ルールで実害なく機能している。リファクタ価値は限定的 |
| `disableBundledSkills` | 低 | 既存スキルを活用中なので無効化動機なし |
| その他のバグ修正・新機能 | 低 | 設定変更を伴わない |

高優先度に該当する `attribution.sessionUrl` のみを本 PR で反映する。

## 変更内容

`home-manager/programs/claude/default.nix` の attribution ブロックに `sessionUrl = false` を追加。コメントで v2.1.183 由来であることと、既存設定だけでは抑止しきれない箇所を補完する目的を明記。

```nix
attribution = {
  commit = "";
  pr = "";
  sessionUrl = false;  # 追加
};
```

## 確認手順

- [ ] `make switch` 適用後、Claude Code を使った commit の message に `Claude-Session:` 行が含まれないこと
- [ ] PR 説明欄にも同様に session link が自動付与されないこと


---
_Generated by [Claude Code](https://claude.ai/code/session_018wW6SA47TU9bgqXThfUkb8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Claude AI設定を更新し、セッションリンクの表示制御を改善しました。帰属情報の処理に関する設定を調整し、より適切な動作を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->