### PR TITLE
feat(claude): v2.1.186 の respondToBashCommands を false で明示固定

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -9,6 +9,13 @@ let
     # インタラクティブセッションでは thinking block が redacted 表示となる。意図と揃える。
     showThinkingSummaries = true;
     autoMemoryEnabled = false;
+    # v2.1.186 で `!` bash コマンドのデフォルト挙動が context-only から Claude が出力に
+    # 対して自動応答する形に変わった。Opus 4.7 + effortLevel = "xhigh" +
+    # AGENT_TEAMS / FORK_SUBAGENT + 1h prompt caching の重い構成では、`!ls` や
+    # `!git status` のような軽い確認コマンドでも自動で API コールが走るとコストが嵩む。
+    # CLAUDE_CODE_DISABLE_FAST_MODE / DISABLE_UPDATES と同じく、意図せぬコスト発生と
+    # サイレントな挙動変化を避けるため旧挙動を明示固定する。
+    respondToBashCommands = false;
     # v2.1.111 で Opus 4.7 向けに追加された `xhigh`（`high` と `max` の中間）。
     # alwaysThinkingEnabled = true と合わせて、Opus 4.7 の推論深度を引き上げる。
     effortLevel = "xhigh";


### PR DESCRIPTION
## 変更点

`home-manager/programs/claude/default.nix` の `baseSettings` に `respondToBashCommands = false;` を追加。

## 何が起きたか（v2.1.143 → v2.1.186 のリリースノート要約）

dotfiles で明示固定済みの最新バージョンは v2.1.143。それ以降の主な変更は以下:

### 設定・環境変数まわり

| ver | 内容 |
| --- | --- |
| 2.1.186 | **`respondToBashCommands` 設定追加。`!` bash コマンドが既定で Claude の自動応答を発火する挙動に変わった**。`false` で旧 context-only 挙動に戻せる |
| 2.1.186 | `teammateMode: "iterm2"` 追加（iTerm2 のペイン分割でチームメイト起動） |
| 2.1.183 | `attribution.sessionUrl` 追加（commit/PR から claude.ai セッションリンクのみを抑止） |
| 2.1.183 | auto mode が `git reset --hard` / `git checkout -- .` / `terraform destroy` 等の破壊的コマンドを既定で拒否 |
| 2.1.181 | `/config key=value` 構文、`sandbox.allowAppleEvents`、`CLAUDE_CLIENT_PRESENCE_FILE` 環境変数 |
| 2.1.178 | **Agent teams 再構成**: `TeamCreate`/`TeamDelete` ツール削除、`team_name` パラメータは ignored、`AGENT_TEAMS=1` で各セッションが暗黙のチームを持つ |
| 2.1.178 | `Tool(param:value)` 構文（例: `Agent(model:opus)` で Opus サブエージェントを拒否） |
| 2.1.175 | `enforceAvailableModels` managed setting |
| 2.1.174 | `wheelScrollAccelerationEnabled` 設定 |
| 2.1.172 | サブエージェントが自前のサブエージェントを最大 5 階層まで spawn 可能 |
| 2.1.170 | **Claude Fable 5 リリース** |
| 2.1.169 | `--safe-mode` フラグと `CLAUDE_CODE_SAFE_MODE` / `disableBundledSkills` / `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` / `/cd` コマンド |
| 2.1.166 | `fallbackModel` 設定（最大 3 つのフォールバックモデル）、deny rule のツール名位置で glob サポート |
| 2.1.163 | `requiredMinimumVersion` / `requiredMaximumVersion` managed setting、Stop/SubagentStop フックの `hookSpecificOutput.additionalContext` |
| 2.1.157 | `.claude/skills` 直下のプラグインを marketplace なしで自動ロード |
| 2.1.154 | **Opus 4.8 リリース**、`/effort xhigh` が既定、dynamic workflows |
| 2.1.152 | `MessageDisplay` フックイベント、`SessionStart` フックで `reloadSkills` / `sessionTitle` 設定可能 |

### 自動で恩恵を受ける既存設定

`autoMode.hard_deny` に `$defaults` を含めているため、v2.1.183 の破壊的 git/IaC コマンドのデフォルト拒否は追加対応不要で適用される。

## なぜ「高」優先度なのか

`respondToBashCommands` は **既定の挙動変更** であり、現在の構成（Opus 4.7 + `effortLevel = "xhigh"` + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` + `CLAUDE_CODE_FORK_SUBAGENT=1` + `ENABLE_PROMPT_CACHING_1H=1`）はターン当たりのコストが非常に高い。

- 旧挙動: `!ls` 等で出力がコンテキストに入るだけで API コールは発生しない
- 新既定: `!` 実行ごとに Claude が出力に応答するため毎回 API コールが走る

軽い確認用途で `!` を多用すると Opus 4.7 + xhigh のターンが連発し、想定外のコストになりうる。

これは `CLAUDE_CODE_DISABLE_FAST_MODE = "1"`（誤投入による Fast Mode 課金事故を防ぐ）/ `DISABLE_UPDATES = "1"`（dotfiles 管理外の更新経路を塞ぐ）/ `worktree.baseRef = "head"`（既定値変更によるサイレント挙動変化の遮断）と同じ「明示固定でサイレント変化を防ぐ」防御深度に該当するため、高優先度として対応する。

## 高優先度に含めなかった項目と理由

### 中

- **`fallbackModel` (2.1.166)**: 重い構成下での overload 耐性向上に有効だが、現状で具体的な障害が発生していない。フォールバック先のモデル選定はユーザーの意思決定が必要なため見送り
- **`Tool(param:value)` 構文 (2.1.178)**: `Agent(model:opus)` 等で細粒度制限が可能になったが、メイン利用が Opus 4.7 のため現状では制限したい対象がない
- **`attribution.sessionUrl` (2.1.183)**: 既に `attribution.commit = ""` / `attribution.pr = ""` で全帰属表示を抑止済み。重複対応のため不要

### 低

- **`CLAUDE_CLIENT_PRESENCE_FILE` (2.1.181)**: モバイル push 抑制の opt-in 機能。`Notification` フックでローカル通知制御済みで、目的が重複
- **`--safe-mode` / `CLAUDE_CODE_SAFE_MODE` (2.1.169)**: トラブルシューティング用フラグで常用しない
- **`disableBundledSkills` (2.1.169)**: bundled skills を非表示にする設定。明示的な不要 skill が出てから対応
- **`enforceAvailableModels` (2.1.175)**: managed setting で組織向け
- **`wheelScrollAccelerationEnabled` (2.1.174)**: 個人嗜好で運用上の差分なし
- **`teammateMode: "iterm2"` (2.1.186)**: 既存の AGENT_TEAMS フロー（tmux/pane）に支障なし
- **Opus 4.8 / Fable 5 への切替**: 現状 Opus 4.7 を明示意図で使用中、別途検討が必要

---
_Generated by [Claude Code](https://claude.ai/code/session_019s5D5fR9Lz3NLrMeXWjNJW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bashコマンドへの自動応答がデフォルトで無効化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->