### PR TITLE
feat(claude): attribution.sessionUrl を false にして帰属抑止を完結させる

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -47,9 +47,15 @@ let
       CLAUDE_CODE_PLUGIN_PREFER_HTTPS = "1";
     };
     # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr 双方の帰属表示を空文字列化して抑止する。
+    # v2.1.183 で追加された `sessionUrl` は web / Remote Control セッションからの commit / PR に
+    # `Claude-Session: https://claude.ai/code/...` トレーラーを付与する独立フラグで、`commit` / `pr`
+    # の空文字列化では塞げない。公式ドキュメント (https://code.claude.com/docs/en/settings#attribution-settings)
+    # でも「all attribution を隠すには `commit` / `pr` を空文字 + `sessionUrl = false`」と明記されており、
+    # 三者を揃えて attribution 抑止の意図を完結させる。
     attribution = {
       commit = "";
       pr = "";
+      sessionUrl = false;
     };
     enabledPlugins = {
       "typescript-lsp@claude-plugins-official" = true;


### PR DESCRIPTION
## 背景

Claude Code v2.1.144 〜 v2.1.187 のリリースノートを確認し、現状の `home-manager/programs/claude/default.nix` の設定と照合した。優先度は以下のように判定。

| 優先度 | 項目 | 適用判断 |
| --- | --- | --- |
| **高** | `attribution.sessionUrl`（v2.1.183 追加） | 本 PR で対応 |
| 中 | `sandbox.credentials`（v2.1.187 追加） | 見送り |
| 低 | Opus 4.8 移行・その他多数のバグ修正 | 見送り |

## このPRの変更

`attribution.sessionUrl = false` を追加して、web / Remote Control セッションからの commit / PR に付与される `Claude-Session: https://claude.ai/code/...` トレーラーを抑止する。

```nix
attribution = {
  commit = "";
  pr = "";
  sessionUrl = false;  # ← 追加
};
```

## なぜ高優先度か

既存設定の意図と実態の間にギャップがある。

- 既存コメントは「attribution 設定で commit / pr **双方**の帰属表示を空文字列化して抑止する」と宣言している
- だが v2.1.183 で `sessionUrl` が独立フラグとして切り出され、`commit` / `pr` の空文字列化では塞げない経路が新設された
- 公式ドキュメント（[settings#attribution-settings](https://code.claude.com/docs/en/settings#attribution-settings)）も「all attribution を隠すには `commit` / `pr` を空文字 + `sessionUrl = false`」と明記
- このユーザーは web / Remote Control 経由でも作業するため、現状の設定では `Claude-Session` トレーラーがコミットに混入する

既存意図を完結させる純粋な穴埋めで、新たな副作用はない。古い Claude Code バージョンでは未知キーとして無視されるため、ロールフォワード時の安全性も担保される。

## 見送った項目

### `sandbox.credentials`（中）

v2.1.187 で追加。sandboxed Bash コマンドからクレデンシャルファイル・秘密の環境変数の読み取りをブロックする。

このドットファイルは `permissions.defaultMode = "auto"` を使い `sandbox.enabled` を有効化していないため、現状適用余地がない。sandbox 機能を導入する判断が出てから合わせて検討する。

### Opus 4.8 移行（低）

v2.1.154 で Opus 4.8 が high effort をデフォルトで投入された。だが既存設定は明示的に Opus 4.7 + `effortLevel = "xhigh"` の運用前提でコメントを書いており、Opus 4.7 を意図して固定している。移行は別判断（コスト・挙動差の評価が必要）なのでこの PR の範囲外とする。

### その他

v2.1.144 〜 v2.1.187 の他のエントリは大半がバグ修正（自動適用）か、現状の設定方針と直交する機能（`teammateMode: "iterm2"`、`wheelScrollAccelerationEnabled` など）か、managed settings 専用（`requiredMinimumVersion`、`enforceAvailableModels`）。dotfiles に反映すべきものはなかった。


---
_Generated by [Claude Code](https://claude.ai/code/session_01AXKMftCjAYjXCAGPTnCn4r)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **設定変更**
  * セッション関連の追跡設定が無効化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->