### PR TITLE
feat(claude): v2.1.193 の autoMode.classifyAllShell を有効化

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -85,7 +85,17 @@ let
     # `permissions.deny` の構文ベース（`Bash(sudo *)` 等）はシェル経由の回避
     # （`bash -lc "sudo ..."` 等）で抜けうるため、同じ defense-in-depth 思想を意図ベースで二重化する。
     # `$defaults` で組み込みルールを継承する。
+    #
+    # v2.1.193 で `classifyAllShell` が追加された。デフォルトでは auto mode 分類器は
+    # 「arbitrary-code-execution パターン」にマッチする shell コマンドのみを評価対象とするため、
+    # `bash -lc "sudo ..."` のような明示的にラップされていない実行経路は分類器を素通りし、
+    # 上の `hard_deny`（"Never run sudo... even via shell wrappers, subshells, or pipes"）が
+    # 評価されないまま実行されうる。`classifyAllShell = true` で全 Bash / PowerShell コマンドを
+    # 強制的に分類器へ通し、意図ベースの hard_deny ルールが必ず評価されるようにする。
+    # 分類器コール分のレイテンシと token コストは増えるが、`hard_deny` を「実際に効くガード」に
+    # するための必須設定であり、defense-in-depth の意図と整合する。
     autoMode = {
+      classifyAllShell = true;
       hard_deny = [
         "$defaults"
         "Never read .env, .env.local, or any other .env.* files in any directory"


### PR DESCRIPTION
## 把握したアップデート (v2.1.186 → v2.1.193)

直近の Claude Code リリースで設定面に影響する主な変更を整理する。

### v2.1.193 (2026-06-25)
- **`autoMode.classifyAllShell`** 追加。全 Bash / PowerShell を auto mode 分類器に通す
- `OTEL_LOG_ASSISTANT_RESPONSES` 環境変数追加
- auto mode の denial 理由が transcript / `/permissions` に表示されるように
- bash モードで file path のライブ補完
- idle なバックグラウンド shell の自動メモリリープ（`CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` で無効化可）

### v2.1.191
- `/rewind` が `/clear` 前会話の resume に対応
- ストリーミング中のスクロール位置ジャンプ修正

### v2.1.187
- `sandbox.credentials` 設定追加
- 組織レベルのモデル制限
- 明示要求なしの destructive git / `terraform destroy` / `pulumi destroy` をブロック
- `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` 環境変数追加

### v2.1.186 (現状の dotfiles 基準)
- `claude mcp login` / `logout` サブコマンド追加
- `teammateMode: "iterm2"` 設定追加
- `/workflows` での status filtering, `/plugin` の Skills セクション

## 優先度判定

| 項目 | 優先度 | 理由 |
| --- | --- | --- |
| `autoMode.classifyAllShell` | **高** | 既存 `hard_deny` の意図ベースルールを実効化する。シェル経由 deny 回避への defense-in-depth 思想と完全に整合し、本 PR で対応 |
| `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` | 中 | MCP サーバーがハングした際の保険。現状 MCP は安定運用中で緊急性なし |
| `sandbox.credentials` | 低 | dotfiles で sandbox を能動利用していない |
| `OTEL_LOG_ASSISTANT_RESPONSES` | 低 | OTEL ロギングを行っていない |
| `CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP` | 低 | デフォルトの自動リープを抑制する設定。現状のワークフローで困っていないため不要 |
| destructive git auto-block | 低 | `permissions.deny` の `Bash(git push*)` と `hard_deny` で既に塞がれており、公式デフォルトが追加で効くだけ |

## 本 PR の変更

`autoMode.classifyAllShell = true` のみ追加。

## なぜ高優先度か

既存 `hard_deny` のコメントに次の懸念が明記されていた:

> `permissions.deny` の構文ベース（`Bash(sudo *)` 等）はシェル経由の回避
> （`bash -lc "sudo ..."` 等）で抜けうるため、同じ defense-in-depth 思想を意図ベースで二重化する。

意図ベースルールとして `"Never run sudo or su commands, even via shell wrappers, subshells, or pipes"` を置いてはいたが、**デフォルトの auto mode 分類器は「arbitrary-code-execution パターン」にマッチする shell コマンドのみを評価対象とする**ため、`bash -lc "sudo ..."` のような明示的にラップされていない実行経路は分類器を素通りし、上記の `hard_deny` が評価されないまま実行されうる構造的な穴があった。

v2.1.193 で追加された `classifyAllShell = true` は、全 Bash / PowerShell コマンドを強制的に分類器へ通し、意図ベースの `hard_deny` ルールが必ず評価される状態にする。分類器コール分のレイテンシ・token コストは増えるが、既に書いた `hard_deny` を「実際に効くガード」にするための必須設定であり、本 PR で他のどの項目より優先する理由となる。


---
_Generated by [Claude Code](https://claude.ai/code/session_01SuTr1PDaPXgVVKqMGRtcei)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 自動モードで、シェル経由のコマンドも必ず分類対象になるようになりました。
  * これにより、想定どおり制限判定が実行され、拒否条件がより確実に評価されます。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->