### PR TITLE
feat(claude): classifyAllShell を有効化して allow 経由の hard_deny 三層防御を完成させる

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -86,6 +86,17 @@ let
     # （`bash -lc "sudo ..."` 等）で抜けうるため、同じ defense-in-depth 思想を意図ベースで二重化する。
     # `$defaults` で組み込みルールを継承する。
     autoMode = {
+      # v2.1.193 で追加。`permissions.allow` にマッチしたシェルコマンドも例外なく
+      # auto-mode classifier 経由でルーティングする。デフォルト挙動では allow ルール
+      # （例: `Bash(git *)` / `Bash(make *)`）にマッチしたコマンドは classifier を
+      # スキップして即座に許可されるため、`hard_deny` の意図ベースルール
+      # （"Never run git push" 等）が allow 経由のコマンドには適用されない穴があった。
+      # `Bash(git push*)` の構文 deny に加えて、`Bash(git *)` allow にマッチした
+      # `git push` 系のコマンドも `hard_deny` で確実にブロックさせ、三層防御を完成させる。
+      # auto mode classifier 経由となるため軽い軽量呼び出しでもレイテンシが乗るが、
+      # 構文ベース回避（`bash -lc "git push ..."` / `make` 経由の sudo 等）を意図ベースで
+      # 塞ぐ価値を優先する。
+      classifyAllShell = true;
       hard_deny = [
         "$defaults"
         "Never read .env, .env.local, or any other .env.* files in any directory"


### PR DESCRIPTION
## 何を変えたか

`home-manager/programs/claude/default.nix` の `autoMode` に `classifyAllShell = true` を追加し、`permissions.allow` にマッチしたシェルコマンドも例外なく auto-mode classifier 経由でルーティングするようにした。

## 調査したアップデート（v2.1.187 → v2.1.195）

現状の dotfiles は v2.1.186 のリリース対応まで（直近コミット `421dde9` / `0a61de1`）反映済み。v2.1.187 以降のリリースノートを精査した結果は以下。

### v2.1.187
- `sandbox.credentials` 設定追加（sandbox 内で利用可能な credentials を明示する許可リスト形式）
- org-configured モデル制限
- フルスクリーンモードでのマウスクリック対応
- 各種バグ修正

### v2.1.190
- バグフィックス・信頼性向上のみ

### v2.1.191
- `/rewind` が `/clear` 以前への復元をサポート
- sandbox ネットワーク権限ダイアログがセッション中の許可ホストを記憶
- MCP サーバーの transient エラー時のリトライロジック
- ストリーミング応答の CPU 使用量約 37% 削減

### v2.1.193
- **`autoMode.classifyAllShell` 設定追加 — すべてのシェルコマンドを auto-mode classifier 経由でルーティング**
- auto-mode 拒否理由を transcript / toast / `/permissions` の Recently denied に表示
- `claude_code.assistant_response` OpenTelemetry log event 追加
- bash mode のライブファイルパス autocomplete
- MCP サーバーが認証必要な場合の起動時通知

### v2.1.195
- `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` 環境変数追加（フルスクリーンモードのマウス操作を無効化、スクロールは維持）
- ハイフンを含む hook matcher が完全一致になる修正
- voice dictation / background job 関連の修正

## 優先度判断

### 高 — `autoMode.classifyAllShell` (v2.1.193) → 本 PR で対応

このリポジトリの Claude Code 設定は `permissions.allow` で `Bash(git *)` / `Bash(make *)` 等の幅広いワイルドカードを許可しつつ、`permissions.deny` の構文ベースと `autoMode.hard_deny` の意図ベースで二重に絞り込む defense-in-depth 思想（v2.1.136 で `hard_deny` を導入した際のコメント参照）。

ただし permission-modes ドキュメントの "How the classifier evaluates actions" によれば、デフォルトでは `permissions.allow` にマッチしたコマンドは classifier をスキップして即座に許可される。つまり `Bash(git *)` allow にマッチした `git push` 系コマンドは、`Bash(git push*)` の構文 deny で塞いではいるものの、`hard_deny` の "Never run git push" は通過時に評価されていなかった。`bash -lc "git push ..."` のような構文回避や、`make` 経由で `sudo` を呼ばれた場合も同様に hard_deny が効かない穴があった。

`classifyAllShell = true` で全シェルコマンドを classifier 経由とすることで、構文 deny → 構文 allow → 意図 hard_deny の三層が全てのシェル実行に対して機能するようになる。既存の設定思想と完全に整合するため高優先度として対応。

### 中 — 設定変更不要だが効果がある変更

- `autoMode` の拒否理由が `/permissions` Recently denied に表示される（v2.1.193, デフォルトで有効）
- MCP サーバーのリトライ・認証通知の改善（v2.1.191/193, デフォルトで有効）
- ストリーミング CPU 削減（v2.1.191, デフォルトで有効）

これらは設定変更なしで恩恵を受けられるため本 PR の対象外。

### 低 — 採用見送り

- `sandbox.credentials` (v2.1.187): sandbox 内で利用可能な credentials を**明示する許可リスト**形式の設定。本 dotfiles では sandbox を使用していないため適用対象外。
- `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` (v2.1.195): マウスクリックの好み依存設定で defense-in-depth とは無関係。必要になった時点で追加すれば足りる。
- `/rewind` 改善・その他 UI 修正: 設定不要。

## トレードオフ

`classifyAllShell = true` は軽量な `ls` や `git status` 系コマンドにも classifier 呼び出しのレイテンシ（small model への round-trip）と少量のトークン消費を追加する。`Bash(git *)` allow にマッチして即座に動いていたものが classifier 経由となる分、体感速度がわずかに落ちる可能性がある。

ただし、構文ベース回避を意図ベース hard_deny で塞ぐ価値（特に `sudo` / `git push` / 機密ファイルアクセス）は、サブセカンドのオーバーヘッドより優先する。`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` / `CLAUDE_CODE_PLUGIN_PREFER_HTTPS` 等で導入した defense-in-depth と同じ判断軸。

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGjkf4SteWb5Eu7CBz47yn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 許可済みのシェルコマンドでも判定を迂回しないようになり、意図しない操作がより確実にブロックされるようになりました。
  * ルールの優先判定が強化され、細かなコマンド指定による拒否条件が期待どおりに適用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->