### PR TITLE
feat(claude): autoMode.classifyAllShell で allow 配下の Bash も分類器経由に強制

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -86,6 +86,17 @@ let
     # （`bash -lc "sudo ..."` 等）で抜けうるため、同じ defense-in-depth 思想を意図ベースで二重化する。
     # `$defaults` で組み込みルールを継承する。
     autoMode = {
+      # v2.1.193 で追加。デフォルトでは `permissions.allow` にマッチした Bash コマンドは
+      # 分類器を素通りし、auto mode の判定（破壊的 git 操作・curl|bash・本番デプロイ等の
+      # `$defaults` ブロック）も適用されない。`Bash(git *)` / `Bash(brew *)` / `Bash(make *)`
+      # のような広い allow ルールを並べている本構成では、allow に該当する範囲内で
+      # `git reset --hard` 等の destructive コマンドが分類器を経ずに通る余地がある。
+      # `hard_deny` を意図ベースで二重化したのと同じ defense-in-depth 思想で、
+      # 全 Bash / PowerShell を分類器経由に強制する。`$defaults` の destructive git ガード
+      # （v2.1.183 で追加された `git reset --hard` 等）も allow 配下のコマンドに効くようになる。
+      # 各コマンドで分類器コールが 1 回増えるが、Opus 4.7 + xhigh + 1h caching の重い構成では
+      # 既に classifier latency より遥かに大きな round-trip を払っており、相対的なオーバーヘッドは小さい。
+      classifyAllShell = true;
       hard_deny = [
         "$defaults"
         "Never read .env, .env.local, or any other .env.* files in any directory"


### PR DESCRIPTION
## 把握したアップデート

flake.lock 固定リビジョン (Claude Code 設定の最新参照は v2.1.186) 以降の release note とドキュメントを確認した結果、関連するアップデートは以下。

### Claude Code: v2.1.187 〜 v2.1.195

| バージョン | 変更点 | 本 dotfiles への適合 |
| --- | --- | --- |
| v2.1.187 | `sandbox.credentials` で sandboxed コマンドの credential ファイル / env var 読み取りを拒否 | 既存設定で `sandbox.enabled = true` を指定していないため、有効化と同時導入が必要。本 PR スコープ外 |
| v2.1.187 | 組織設定によるモデル制限（managed） | 個人 dotfiles では不要 |
| v2.1.181 | `sandbox.allowAppleEvents` | 同上、sandbox 未有効 |
| v2.1.181 | `/config key=value` 構文 | 設定対象ではなくランタイム機能 |
| v2.1.183 | auto mode で `git reset --hard` 等の destructive git コマンドをデフォルト拒否 | 設定変更不要。`autoMode.hard_deny` の `$defaults` 継承により自動で効く |
| v2.1.178 | `Agent(param:value)` 構文で権限ルール内のツール入力をマッチング | nice-to-have、現状の運用で不足は出ていない |
| v2.1.169 | `--safe-mode` フラグ・`disableBundledSkills` | フラグまたは UI 設定で、defense-in-depth 構成への適合度低 |
| v2.1.166 | `fallbackModel`（3 段フォールバック） | Opus 4.7 を意図的に指定しており、過負荷時のサイレントなモデル降格より明示的にエラーになる方が好ましい |
| v2.1.193 | **`autoMode.classifyAllShell`** で全 Bash / PowerShell コマンドを分類器経由に強制 | **本 PR の対象** |
| v2.1.195 | `CLAUDE_CODE_DISABLE_MOUSE_CLICKS`、音声入力修正等 | UI / プラットフォーム個別 fix |

### nix-darwin / home-manager / nixpkgs (25.11 系)

- nix-darwin: `ebec37af` (2026-02-26) 以降の release-25.11 への追加なし
- home-manager: release-25.11 に minor な依存更新のみ
- nixpkgs-25.11-darwin: routine な package bump のみ（aarch64-darwin 構成に影響する破壊的変更なし）

いずれもこのタイミングで反映が必要な変更は見当たらない。

## 優先度判定

### 高: `autoMode.classifyAllShell = true`

既存の `autoMode.hard_deny` 設定では「`permissions.deny` の構文ベースはシェル経由の回避（`bash -lc "sudo ..."` 等）で抜けうるため defense-in-depth で意図ベースに二重化する」という方針を明文化しているが、デフォルトでは `permissions.allow` にマッチした Bash コマンドは分類器を**素通り**し、`$defaults` の destructive ガード（`git reset --hard` / `curl | bash` / 本番デプロイ等）も適用されない。

本 dotfiles では `Bash(git *)` / `Bash(brew *)` / `Bash(make *)` / `Bash(nix *)` 等の広い allow ルールを並べているため、allow に該当する範囲内で destructive コマンドが分類器を経ずに通る余地が残っていた。`classifyAllShell = true` でこの穴を塞ぎ、既存の defense-in-depth 方針と整合させる。

「同じ思想の defense-in-depth 強化」「allow ルールを狭めずに安全側に倒せる」「コストは分類器 1 コール / 各 Bash 実行で、Opus 4.7 + `xhigh` + 1h prompt caching の重い構成では相対的に軽微」という観点で、**高優先度**と判定した。

### 中・低

- `sandbox.*` 系: 価値はあるが `sandbox.enabled = true` への移行を伴い、`enable Sandbox -> per-skill での無効化方針との整合` を含めて別途検討すべき範囲のため見送り
- `fallbackModel`: 現運用ではフォールバックよりエラーで気づく方が好ましく不要
- flake input 更新: 互換性に影響する変更を含まず、`make update` の通常運用に任せられる

## 変更内容

`home-manager/programs/claude/default.nix` の `autoMode` ブロックに `classifyAllShell = true;` を追加し、判断根拠（v2.1.193 の挙動・既存 allow ルールとの関係・コスト評価）をコメントで明示した。

---
_Generated by [Claude Code](https://claude.ai/code/session_014BYRkdqXvGsVWx6tUkegU5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * シェルコマンドの判定対象を拡張し、許可済みのコマンドでも分類器による確認が行われるようになりました。
  * これにより、Bash/PowerShell コマンドの扱いがより一貫し、安全性チェックが強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->