### PR TITLE
feat(claude): autoMode.classifyAllShell で allow パターン経由の抜け穴を塞ぐ

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -86,6 +86,15 @@ let
     # （`bash -lc "sudo ..."` 等）で抜けうるため、同じ defense-in-depth 思想を意図ベースで二重化する。
     # `$defaults` で組み込みルールを継承する。
     autoMode = {
+      # v2.1.193 で追加。デフォルトでは auto mode classifier は arbitrary-code-execution
+      # パターンに該当する Bash / PowerShell コマンドにしか走らないため、`permissions.allow`
+      # の `Bash(git *)` / `Bash(cd *)` 等で構文ベース許可されたコマンドは classifier を
+      # スキップし、`hard_deny` の intent-based ルールが評価されない経路が残っていた。
+      # `classifyAllShell = true` で全 shell コマンドを classifier に通し、
+      # `Bash(git *)` 経由の `git push` や、allow に近いラッパー越し sudo を `hard_deny` で
+      # 確実に阻止する。`permissions.deny` の構文ベース禁止と `hard_deny` の意図ベース禁止を
+      # 二重化する既存の defense-in-depth 思想（下記コメント参照）を完成させる。
+      classifyAllShell = true;
       hard_deny = [
         "$defaults"
         "Never read .env, .env.local, or any other .env.* files in any directory"


### PR DESCRIPTION
## 背景: 直近の Claude Code リリース内容

v2.1.186（現状の dotfiles が参照している最新）以降に次のリリースが出ている。

| ver | 主な変更 |
| --- | --- |
| v2.1.187 | `sandbox.credentials` 設定追加、org-configured model 制限 UI |
| v2.1.190 | バグ修正のみ |
| v2.1.191 | `/rewind` で `/clear` 後の resume、sandbox network permission の session 内記憶 |
| v2.1.193 | **`autoMode.classifyAllShell` 設定追加**、`OTEL_LOG_ASSISTANT_RESPONSES` 追加、`!` の live path autocomplete |
| v2.1.195 | `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` 追加、hook matcher のハイフン完全一致化 |

## 優先度判断

| 項目 | 優先度 | 理由 |
| --- | --- | --- |
| `autoMode.classifyAllShell` | 高 | 現 dotfiles の defense-in-depth 思想（`permissions.deny` の構文ベース禁止と `autoMode.hard_deny` の意図ベース禁止の二重化）の前提を完成させる。詳細は下記。 |
| `sandbox.credentials` | 中 | 既に `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` で subprocess の secrets 剥奪は実施済み。macOS で sandbox を強制している記述が無く、追加効果が限定的。 |
| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` | 低 | UX の好み。設定の真実の所在を縛る必要なし。 |
| `OTEL_LOG_ASSISTANT_RESPONSES` | 低 | OpenTelemetry エクスポート設定を入れていないので無関係。 |
| `/rewind` for `/clear` 等 | 低 | 機能挙動の改善のみで設定対象なし。 |

高に該当する `autoMode.classifyAllShell` のみ本 PR で対応する。

## なぜ高優先度か

既存の設定では次の二段構えで操作を縛っている。

- `permissions.deny`: `Bash(sudo *)`, `Bash(git push*)` 等の構文ベース禁止
- `autoMode.hard_deny`: "Never run sudo or su ..." "Never run git push ..." 等の意図ベース禁止

既存コメントは「`permissions.deny` は `bash -lc "sudo ..."` のようなシェル経由で抜けうるため、意図ベースで二重化する」と明言している。

しかし auto mode classifier はデフォルトで arbitrary-code-execution パターンに該当する shell コマンドにしか走らない。つまり `permissions.allow` の `Bash(git *)` / `Bash(cd *)` で構文ベース許可されたコマンドは classifier をスキップする経路が残っており、`hard_deny` の "Never run git push" が評価されないケースが生まれうる。

`classifyAllShell = true` を有効にすると全 Bash / PowerShell コマンドが classifier を通るため、`Bash(git *)` 経由の `git push` も `hard_deny` の意図判定で阻止できる。これは既存の defense-in-depth 思想の前提を完成させる変更で、新規の挙動追加ではなく既存意図のギャップ補修にあたる。

## トレードオフ

全 shell コマンドが classifier を経由するため classifier 呼び出し回数は増える。ただし classifier 自体は軽量モデルで走る前提で、`respondToBashCommands = false` で抑制している自動応答型 API コール（重い構成での Opus 呼び出し）とはコスト構造が異なる。security 上の defense-in-depth を取る選択。

## 参考

- リリースノート: https://github.com/anthropics/claude-code (v2.1.193)
- 設定ドキュメント: https://code.claude.com/docs/en/settings#auto-mode-settings

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qq4jwPL5SM1jiLEta5qriC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 自動モードでシェルコマンドの判定が常に行われるようになり、一部のコマンドが意図せず許可判定をすり抜ける問題を防ぎました。
  * 既存の制限ルールがより一貫して適用されるようになり、コマンド実行時の安全性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->