### PR TITLE
feat(claude): autoMode.classifyAllShell を有効化して allow-listed shell も分類器経由にする

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -93,6 +93,17 @@ let
         "Never run sudo or su commands, even via shell wrappers, subshells, or pipes"
         "Never run git push — the user pushes manually"
       ];
+      # v2.1.193 で追加。auto mode 中、`Bash(*)` のような広い allow を除く narrow な
+      # Bash / PowerShell allow rule はデフォルトで分類器を素通りする。
+      # 本設定の `permissions.allow` には `Bash(git *)` / `Bash(sed *)` / `Bash(cp *)` /
+      # `Bash(chmod *)` 等、prefix が想定していない破壊的引数を許してしまう幅の広い
+      # パターンが含まれる（例: `sed -i` で任意ファイル書き換え、`cp` で機密ファイル退避、
+      # `git reset --hard` で未 push commit の破棄）。
+      # `true` にすると全 shell コマンドが分類器を通り、上の `hard_deny` の自然言語ルール
+      # （"Never read files under ~/.ssh" / "Never run sudo ..." 等）が allow-listed shell に
+      # 対しても効くようになる。分類器 1 コール分のレイテンシが乗るが、
+      # ENABLE_PROMPT_CACHING_1H で速度より defense-in-depth を優先している既存方針と揃える。
+      classifyAllShell = true;
     };
     permissions = {
       defaultMode = "auto";


### PR DESCRIPTION
## 背景: Claude Code のアップデート概観

release note (v2.1.186 → 最新 v2.1.197) を確認した中で、本 dotfiles に反映すべきと判断したのは以下のみ。

### 高（本 PR で対応）

- **`autoMode.classifyAllShell`** (v2.1.193)
  auto mode 中に narrow な Bash / PowerShell allow rule を分類器バイパスさせないフラグ。

### 中 / 低（見送り）

- `sandbox.credentials` (v2.1.187 / v2.1.191)
  sandbox から特定 credential ファイルへの opt-in アクセスを許可する設定。本 dotfiles は逆に `.env` / `~/.ssh` / `~/.aws` / `secrets.jsonnet` を `permissions.deny` / `autoMode.hard_deny` の双方でブロックする方向なので不採用。
- `sandbox.allowAppleEvents` (v2.1.187)
  sandbox コマンドから Apple Events を有効化する opt-in 設定。現状 sandbox 側の要件が無いため見送り。
- Sonnet 5 / Opus 4.8 の default 化 (v2.1.197 / v2.1.154)
  既存設定は `alwaysThinkingEnabled = true` + `effortLevel = "xhigh"` を Opus 4.7 前提でチューニング済み。model は明示せず provider default に委ねる現状構成を壊さないため、settings 上での明示的な model 固定は本 PR では行わない。
- `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` (v2.1.195) / `wheelScrollAccelerationEnabled`
  UX 選好。症状が出ていないため見送り。
- `CLAUDE_CODE_ENABLE_STREAM_WATCHDOG` / `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT`
  ストリーム停滞 / MCP 5 分タイムアウトの症状が発生したときに検討。予防的に入れる性質ではない。

## この PR の変更内容

`home-manager/programs/claude/default.nix` の `autoMode` ブロックに `classifyAllShell = true` を追加。

## なぜ「高」としたか

本 dotfiles の Claude Code 設定は、以下のように「速度より defense-in-depth を優先する」philosophy が既に随所に埋め込まれている。

- `permissions.defaultMode = "auto"` + `autoMode.hard_deny` に "Never run sudo ...", "Never run git push", "Never read files under ~/.ssh ..." 等の自然言語ルール
- `permissions.deny` に `Bash(git push*)` / `Bash(sudo *)` / `Read(.env)` / `Read(~/.ssh/**)` 等の構文ベースルール
- `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = "1"` による subprocess env の credential 剥奪

一方で `permissions.allow` は `Bash(git *)` / `Bash(sed *)` / `Bash(cp *)` / `Bash(chmod *)` 等、prefix が想定していない破壊的引数まで許してしまう幅の広い allow を含む。default 挙動ではこれら narrow な allow は分類器を素通りするため、以下のような抜け道が残る:

- `sed -i "..." ~/.zshrc` → 任意ファイル書き換え
- `cp secrets.jsonnet /tmp/leak` → 機密ファイル退避（`Read(**/secrets.jsonnet)` deny は Read tool 用で bash 経由の cp は対象外）
- `git reset --hard` → 未 push commit の破棄
- `chmod 777 ~/.ssh` → 権限緩和

`classifyAllShell = true` にすると allow の narrow rule も分類器経由となり、既存の `autoMode.hard_deny` の自然言語ルールが allow-listed shell に対しても発火するようになる。既に構文ベース / 自然言語ベースの二重防御を敷いている以上、この抜け道を塞ぐことは既存 philosophy との整合性が高く、優先度「高」と判断。

トレードオフとして、shell 1 コマンドあたり分類器 1 コール分のレイテンシが乗るが、`ENABLE_PROMPT_CACHING_1H` で「速度より defense-in-depth 優先」の方針を採っている既存構成と揃う。

## 参考

- [Configure auto mode - Route all shell commands through the classifier](https://code.claude.com/docs/en/auto-mode-config#route-all-shell-commands-through-the-classifier)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyytEDKaEhgqYGji2Cxsui)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * auto mode で、広い許可ルールに一致するシェルコマンドも分類器を通して判定されるようになりました。
* **改善**
  * `.env`、`~/.ssh`、`sudo` などの禁止ルールが、許可済みのシェルコマンドにも適用されることが明確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->