### PR TITLE
feat(claude): v2.1.193 の autoMode.classifyAllShell を有効化

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -85,7 +85,18 @@ let
     # `permissions.deny` の構文ベース（`Bash(sudo *)` 等）はシェル経由の回避
     # （`bash -lc "sudo ..."` 等）で抜けうるため、同じ defense-in-depth 思想を意図ベースで二重化する。
     # `$defaults` で組み込みルールを継承する。
+    #
+    # v2.1.193 で追加された `classifyAllShell = true` で allow rules を suspend し、
+    # 全 Bash / PowerShell コマンドを分類器に通す。既存の `permissions.allow` は
+    # `Bash(cp *)` / `Bash(chmod *)` / `Bash(sed *)` / `Bash(awk *)` 等を含み、
+    # これらは分類器をバイパスするため `cp ~/.ssh/id_rsa /tmp/` や
+    # `chmod +r ~/.ssh/*` / `sed 'e cmd' ...` で `hard_deny` の意図を素通りできてしまう。
+    # 全コマンドを分類器に通すことで hard_deny の適用域をシェル全域に広げる。
+    # 代償として Bash 呼び出しごとに分類器コールが 1 回増えるが、
+    # `respondToBashCommands = false` で `!` 経由の自動応答は既に抑止済みで、
+    # ツール経由の Bash に対する分類器コストは credential 保護の価値と釣り合う。
     autoMode = {
+      classifyAllShell = true;
       hard_deny = [
         "$defaults"
         "Never read .env, .env.local, or any other .env.* files in any directory"


### PR DESCRIPTION
## 変更内容

`home-manager/programs/claude/default.nix` の `autoMode` に `classifyAllShell = true`（v2.1.193 で追加）を加え、`permissions.defaultMode = "auto"` の分類器を全 Bash / PowerShell コマンドに適用する。

## 前提：現在 tracking 済みのバージョン

コード中のコメントは v2.1.186 の `respondToBashCommands` まで追随済み。今回は v2.1.187 〜 v2.1.201 のリリースノートを見直した結果、以下の 1 件を高優先度と判定して反映する。

## 各リリースのアップデート要旨と優先度

### 高 — 本 PR で対応

- **v2.1.193 `autoMode.classifyAllShell`**：allow rules を suspend して全 Bash / PowerShell を分類器に通す設定。既存の `permissions.allow` には `Bash(cp *)` / `Bash(chmod *)` / `Bash(sed *)` / `Bash(awk *)` などが並んでおり、これらは分類器をバイパスするため `cp ~/.ssh/id_rsa /tmp/` や `chmod +r ~/.ssh/*`、`sed 'e cmd' ...` で `hard_deny` の意図（`~/.ssh` / `~/.aws` / secrets の読取禁止）を素通りできてしまう。`classifyAllShell = true` で hard_deny の適用域をシェル全域に広げる。代償として Bash 呼び出しごとに分類器コールが 1 回増えるが、`respondToBashCommands = false` で `!` 経由の自動応答コストは既に抑止済みで、ツール経由の Bash に対する分類器コストは credential 保護の価値と釣り合う。

### 中 — 反映見送り

- **v2.1.187 `sandbox.credentials`**：`~/.aws` / `~/.ssh` / `secrets.jsonnet` を sandbox 内で deny し、`GITHUB_TOKEN` / `NPM_TOKEN` などを env から unset できる。ただし `sandbox.enabled = true` が前提で、sandbox 全体の導入は挙動変更が大きく別 PR で検討したい。`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = "1"` で Anthropic / cloud provider credentials に限って類似の防御は既に確保されているため、緊急度は低い。
- **v2.1.197 デフォルトモデルが Sonnet 5 に変更**：dotfiles は `model` を設定していないため、デフォルトが Sonnet 5 に切り替わっている。コメントは "Opus 4.7 + effortLevel = xhigh" を前提としているが、モデル固定はユーザーの意向確認が必要なため本 PR では触らない。
- **v2.1.200 `askUserQuestionTimeout`**：デフォルト `"never"` のまま維持で問題なし。明示設定不要。
- **v2.1.200 デフォルト permission mode が "Manual" に変更**：dotfiles は `defaultMode = "auto"` を明示しているため影響なし。

### 低 — 対応不要

- **v2.1.201** Sonnet 5 の mid-conversation system role 削除（透過的）
- **v2.1.199** SSL エラー UX 改善、`mask` credential mode（sandbox 前提）
- **v2.1.198** subagent 背景実行既定化、`Notification` フック経由の subagent 通知、`/dataviz` skill 追加、Explore の model 継承、Sonnet 5 の extended thinking 継承。既存の `Notification` フック運用と互換で対応不要
- **v2.1.196** `enableArtifact` / `enabledMcpjsonServers` / `enableAllProjectMcpServers`、`/code-review` の token 削減、stream watchdog デフォルト有効化
- **v2.1.195** `CLAUDE_CODE_DISABLE_MOUSE_CLICKS`（UX 好み次第）
- **v2.1.191** `/rewind` の `/clear` 対応、CPU 使用量 37% 削減
- **v2.1.190** 修正のみ
- **v2.1.187** その他の org model restrictions / mouse clicks 等（管理者向け）


---
_Generated by [Claude Code](https://claude.ai/code/session_01PhXFTye54FKCZM6LNUCajG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 自動モードで、Bash / PowerShell のコマンドが一律で分類されるようになりました。
  * これにより、許可設定をすり抜けて処理されるケースが抑えられ、権限制御がより一貫します。
  * 自動モードの挙動について、設定内容が分かりやすくなる説明コメントも追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->