### PR TITLE
feat(claude): v2.1.193 の autoMode.classifyAllShell を有効化

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -85,7 +85,16 @@ let
     # `permissions.deny` の構文ベース（`Bash(sudo *)` 等）はシェル経由の回避
     # （`bash -lc "sudo ..."` 等）で抜けうるため、同じ defense-in-depth 思想を意図ベースで二重化する。
     # `$defaults` で組み込みルールを継承する。
+    #
+    # v2.1.193 で追加された `classifyAllShell` は、auto mode の分類器を走らせる対象を
+    # 「arbitrary-code-execution パターンに一致した Bash/PowerShell のみ」から
+    # 「すべての Bash/PowerShell」に広げる。既存の allow ルール（`Bash(git *)` 等）は
+    # auto mode 有効中は一律サスペンドされ、`hard_deny` を含む分類器評価が必ず走る。
+    # これがないと `bash -lc "sudo ..."` のようにパターン検出をすり抜けたコマンドは
+    # 分類器自体が呼ばれず、`Never run sudo ... even via shell wrappers` の意図ルールも
+    # 評価されないままとなる。パターン依存の deny の穴を分類器で塞ぐ、最後の砦。
     autoMode = {
+      classifyAllShell = true;
       hard_deny = [
         "$defaults"
         "Never read .env, .env.local, or any other .env.* files in any directory"


### PR DESCRIPTION
## Claude Code v2.1.186 以降のアップデート調査結果

現行 dotfiles は v2.1.186 まで追随済み（`respondToBashCommands = false` を明示固定）。v2.1.187〜v2.1.202 の全変更を確認し、反映すべき項目を優先度別に分類した。

| バージョン | 変更内容 | 判定 |
| --- | --- | --- |
| v2.1.187 | `sandbox.credentials` でサンドボックス化コマンドから認証情報を剥ぐ | **低** — 現状 `sandbox` 設定を使っていないため実効性なし |
| v2.1.191 | `/rewind` で `/clear` 前の会話から再開 | **低** — 対話コマンドの追加。設定不要 |
| v2.1.193 | **`autoMode.classifyAllShell`** で全 Bash/PowerShell を分類器経由に | **高** — 後述 |
| v2.1.193 | Auto-mode denial reason 表示 | **低** — UI 改善。設定不要 |
| v2.1.194 | `/cd` コマンド、`--safe-mode` フラグ、MCP policies | **低** — 対話/CLI 機能。設定不要 |
| v2.1.195 | `CLAUDE_CODE_DISABLE_MOUSE_CLICKS`、hook matcher のハイフン修正 | **低** — フルスクリーン運用ではないため不要 |
| v2.1.196 | `.mcp.json` セルフ承認警告、未信頼ワークスペース表示 | **低** — 挙動改善のみ、設定不要 |
| v2.1.197 | Claude Sonnet 5 導入 | **低** — Opus 4.7 + `xhigh` 前提のため対象外 |
| v2.1.198 | Subagent デフォルト背景実行、Notification hook に `agent_needs_input` / `agent_completed` 追加 | **中** — Notification matcher の細分化は運用改善余地あり。ただし現行 `notify.ts` の動作確認が必要で、単独 PR で扱うべきなので本 PR には含めない |
| v2.1.198 | `/dataviz` skill、Chrome GA | **低** — バンドル skill 追加。設定不要 |
| v2.1.199 | Stacked slash-skill | **低** — 対話機能。設定不要 |
| v2.1.200 | AskUserQuestion のデフォルト自動継続廃止、permission mode デフォルトが `Manual` に | **低** — `permissions.defaultMode = "auto"` を明示指定済みなので影響なし |
| v2.1.201 | Sonnet 5 会話中システムロール削除 | **低** — 対象外 |
| v2.1.202 | Dynamic workflow size 設定、OTEL 属性追加 | **低** — 使用時に個別設定する程度 |

## 本 PR の変更

`autoMode.classifyAllShell = true` を有効化する 1 行追加。

## なぜ「高」優先度と判断したか

現行の `autoMode.hard_deny` には次の意図ベースルールがある：

```
"Never run sudo or su commands, even via shell wrappers, subshells, or pipes"
```

このルールは **auto mode 分類器が走ったときにだけ評価される**。既定の auto mode は「arbitrary-code-execution パターンに一致した Bash」しか分類器に載せないため、`bash -lc "sudo ..."` のようにパターン検出をすり抜けたコマンドは分類器自体が呼ばれず、意図ルールも評価されないまま素通りする穴があった。

`classifyAllShell = true` により：
- 全 Bash/PowerShell が分類器を経由する
- auto mode 中は `allow` ルール（`Bash(git *)` 等）も一律サスペンドされ、必ず分類器が判定する
- `hard_deny` の意図ルールが確実に評価される

現行ファイル内のコメントで既に「`permissions.deny` の構文ベースはシェル経由の回避で抜けうる」と明記されており、この穴を塞ぐことが `hard_deny` を追加した動機そのもの。`classifyAllShell` は分類器を「必ず走らせる」ためのスイッチで、`hard_deny` の実効性を担保する最後の砦にあたる。他の変更が UI・対話・機能追加中心なのに対し、この 1 項目のみ実害（意図しない特権操作の実行）に直結するため「高」とした。


---
_Generated by [Claude Code](https://claude.ai/code/session_01SZrXViveCbbxAzU9BdpZsC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 自動モード使用時に、シェル経由の実行がより厳密に判定されるようになりました。
  * 既存の許可ルールをすり抜ける可能性を抑え、危険な操作の見逃しを減らしました。
  * Bash / PowerShell からの実行でも、常に分類チェックが行われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->