### PR TITLE
feat(claude): v2.1.193 の autoMode.classifyAllShell を有効化する

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -86,6 +86,18 @@ let
     # （`bash -lc "sudo ..."` 等）で抜けうるため、同じ defense-in-depth 思想を意図ベースで二重化する。
     # `$defaults` で組み込みルールを継承する。
     autoMode = {
+      # v2.1.193 で追加。auto mode 中に narrow な Bash / PowerShell allow ルール
+      # （`Bash(sed *)` / `Bash(chmod *)` 等）を分類器の前段で通さず、全ての shell
+      # コマンドを classifier に評価させる。auto mode のデフォルトは `Bash(*)` 等の
+      # 広い allow のみを停止し、narrow allow は素通しするため、`Bash(sed *)` は
+      # `sed -i` で任意ファイルを書き換えうるし `Bash(chmod *)` は `chmod +s` で
+      # setuid を付与しうる。`permissions.deny` は構文一致、`hard_deny` はシェル
+      # ラッパー経由の回避を意図ベースで拒否するのに対し、`classifyAllShell` は
+      # narrow allow の「意図しない引数」の抜け道を classifier 評価で塞ぐ第三の
+      # 層。トレードオフとして classifier 呼び出しが増えるが、xhigh + 1h キャッシュ
+      # の構成では受容範囲、かつ予測可能性の方が価値が高い。auto mode 外では
+      # 通常通り allow が働くため運用摩擦は限定的。
+      classifyAllShell = true;
       hard_deny = [
         "$defaults"
         "Never read .env, .env.local, or any other .env.* files in any directory"


### PR DESCRIPTION
## Claude Code v2.1.186 → v2.1.203 の主要アップデート

現在の dotfiles は v2.1.186 の変更まで反映済み。以降のリリースを一通り確認し、dotfiles に反映すべき点を洗い出した。

### 反映優先度の分類

#### 高（本 PR で対応）

**v2.1.193: `autoMode.classifyAllShell` 追加**

auto mode のデフォルトは `Bash(*)` 等の広い allow のみを停止し、`Bash(sed *)` / `Bash(chmod *)` のような narrow allow は素通しする。既存の `autoMode.hard_deny` は「シェルラッパー経由の bypass」を意図ベースで拒否するが、narrow allow 自体の「意図しない引数」（`sed -i` での任意ファイル書き換え、`chmod +s` での setuid 付与など）は分類器を通らないため塞げていなかった。`classifyAllShell = true` で narrow allow を含む全 shell コマンドを classifier に通し、既存の `permissions.deny`（構文一致）+ `hard_deny`（意図ベース）と揃えて defense-in-depth を完結させる。

#### 中（今回は見送り／将来検討）

- **v2.1.187: `sandbox.credentials`** — `~/.aws` / `~/.ssh` / `secrets.jsonnet` 等を sandbox から明示的に deny / mask できる新機構。ただし `sandbox.enabled = true` が前提で、有効化は現行の運用と挙動変更が大きいため単独 PR で検討する。現在は `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` と `permissions.deny` + `hard_deny` で類似の保護を張っており、緊急性は低い。
- **v2.1.200: `askUserQuestionTimeout`** — `AskUserQuestion` のアイドルタイムアウトが明示的継続を要求する挙動に変わった。既存の運用で困っていないためデフォルト（opt-out）のまま。困った時点で opt-in を検討する。
- **v2.1.182: `disableClaudeAiConnectors`** — claude.ai 経由の MCP connector を無効化する設定。CLI 主体の運用では影響が小さい。

#### 低（対応不要）

- **v2.1.197: Claude Sonnet 5 デフォルト化** — `effortLevel = "xhigh"` は Opus 4.7 向けなので現行モデル固定を維持。
- **v2.1.200: Permission mode `default` → `Manual` リネーム** — `defaultMode = "auto"` 使用中で影響なし。
- **v2.1.198: `/dataviz` skill 追加**、**v2.1.203: VSCode Remote Control toggle** 等 — 現行の運用と直接関係しない UI / スキル追加。

## 変更内容

`home-manager/programs/claude/default.nix` の `autoMode` ブロックに `classifyAllShell = true` を追加。トレードオフ（classifier 呼び出しの増加）と、xhigh + 1h キャッシュ構成で予測可能性を優先する判断根拠をコメントに記述した。

## 参考

- [Configure auto mode - Route all shell commands through the classifier](https://code.claude.com/docs/en/auto-mode-config#route-all-shell-commands-through-the-classifier)
- Claude Code CHANGELOG（v2.1.187 〜 v2.1.203）

---
_Generated by [Claude Code](https://claude.ai/code/session_017aeXyUXj4VcZzv1girLaLi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 自動判定モードで、Bash/PowerShell の許可判定がより厳密になりました。
  * 一部のコマンドで発生していた、想定外の引数を使ったすり抜けを防止しました。
  * シェルコマンド全体を評価するようになり、許可判定の一貫性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->