### PR TITLE
feat(claude): v2.1.198 の agent_completed を Notification matcher で除外

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -166,10 +166,18 @@ let
       # 受け取りの中間ターンでも通知が走り、マルチエージェント時の S/N 比が悪化していた。
       # `Notification` は Claude Code が能動的にユーザーへ知らせたい状況（メイン完了の
       # idle_prompt、権限要求の permission_prompt、認証成功、MCP elicitation 等）でのみ
-      # 発火する。サブエージェント完了は `SubagentStop` 側に振り分けられるため、
-      # `Notification` のみ登録すれば望ましいタイミングだけ通知を受け取れる。
+      # 発火するため、旧来は `matcher = ""` で全種別を受け取っても S/N は保てた。
+      #
+      # v2.1.198 でサブエージェントが背景実行デフォルトとなり、同時に `Notification` に
+      # `agent_needs_input`（人の介入要求）と `agent_completed`（サブエージェント完了）が
+      # 追加された。CLAUDE_CODE_FORK_SUBAGENT=1 + AGENT_TEAMS の並列度が高い構成では
+      # `agent_completed` が完了ごとに大量発火し、旧「Stop 抑止で S/N を保つ」意図が
+      # 破壊される。`matcher` に受け取りたい種別だけを `|` 区切りで列挙し、
+      # `agent_completed` を除外して意図を維持する。人の介入を促す `agent_needs_input` は残す。
+      # matcher は英数字・`_`・`-`・`|`・`,` のみを含む場合は exact string の集合として
+      # 評価される（正規表現ではない）ため、`|` 列挙で確定的に絞れる。
       Notification = [{
-        matcher = "";
+        matcher = "permission_prompt|idle_prompt|auth_success|elicitation_dialog|elicitation_complete|elicitation_response|agent_needs_input";
         hooks = [{
           type = "command";
           command = "${dotfilesPath}/home-manager/programs/claude/hooks/notify.ts";

--- a/home-manager/programs/claude/hooks/notify.ts
+++ b/home-manager/programs/claude/hooks/notify.ts
@@ -11,6 +11,8 @@ interface HookData {
     | "elicitation_dialog"
     | "elicitation_complete"
     | "elicitation_response"
+    | "agent_needs_input"
+    | "agent_completed"
   message?: string
 }
 


### PR DESCRIPTION
## 背景 — v2.1.193 → v2.1.207 の変更点

現状の `default.nix` は v2.1.193 まで意図固定済み。今回、v2.1.195 〜 v2.1.207 のリリースノートを精査し、優先度別に整理した。

### 高

| 変更点 | 版 | 現状への影響 |
|---|---|---|
| Notification に `agent_needs_input` / `agent_completed` 追加 + サブエージェント背景実行のデフォルト化 | v2.1.198 | 既存の「Notification は Claude が能動的に知らせたい状況でのみ発火する」前提が破壊。`CLAUDE_CODE_FORK_SUBAGENT=1` + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` の並列度が高い構成では、`agent_completed` がサブエージェント完了ごとに発火し、旧来コメントに書いた「Stop 抑止で S/N を保つ」設計意図が壊れる |

### 中・低（本 PR では反映しない）

| 変更点 | 版 | 反映しない理由 |
|---|---|---|
| `CLAUDE_ENABLE_STREAM_WATCHDOG` デフォルト on | v2.1.198 | 既存の xhigh + 拡張思考の運用と齟齬なし。デフォルトのままで十分 |
| `CLAUDE_CODE_RETRY_WATCHDOG` で `CLAUDE_CODE_MAX_RETRIES` cap を 300 に解放 | v2.1.199 | 現状 `MAX_RETRIES` を設定していない。opt-in 型で必要が生じたときに検討 |
| system の `permissions.defaultMode` デフォルトが `manual` に変更 | v2.1.200 / v2.1.203 | `defaultMode = "auto"` を既に明示済み。挙動は不変 |
| `disableAutoMode` 追加 | v2.1.207 | Bedrock / Vertex / Foundry 向け。直接 Anthropic API 利用なので該当なし |
| Hook matcher のハイフン厳密マッチ化 | v2.1.195 | 現行 matcher にハイフン識別子なし。該当なし |
| `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` 等 UI/UX 変更 | v2.1.195 他 | 挙動固定の観点で必須ではない |
| Sonnet 5 / Fable 5 のデフォルト化 | v2.1.197 / v2.1.170 | Opus 4.7 + `effortLevel = "xhigh"` で固定運用。無関係 |
| MCP `request_timeout_ms` / `CLAUDE_CODE_EXTRA_BODY` per-server | v2.1.203 | 現状の MCP 設定でタイムアウト調整の必要性なし |
| `fallbackModel` / `--fallback-model` | v2.1.166（既存） | Opus 4.7 固定運用のため fallback を許容しない |

## 変更内容

- `home-manager/programs/claude/default.nix`
  - `hooks.Notification.matcher` を `""`（全種別受信）から `|` 区切りの明示列挙に変更。`agent_completed` を除外し、人の介入を要求する `agent_needs_input` は残す
  - matcher は英数字・`_`・`-`・`|`・`,` のみで構成される場合は exact string の集合として評価される（正規表現ではない）ことをコメントで明記
  - v2.1.198 の挙動変化と本 matcher の意図を説明する背景コメントを追加
- `home-manager/programs/claude/hooks/notify.ts`
  - `HookData.notification_type` に `agent_needs_input` / `agent_completed` を追加し、matcher 変更前後で型網羅性を保つ

## 高優先度と判断した理由

`default.nix` の既存コメントは「サブエージェント完了は `SubagentStop` 側に振り分けられるため、`Notification` のみ登録すれば望ましいタイミングだけ通知を受け取れる」と明記している。v2.1.198 でこの前提が根本から変わっており、放置すると `CLAUDE_CODE_FORK_SUBAGENT=1` + `AGENT_TEAMS` の重い並列構成でサブエージェント完了ごとに通知が飛ぶ状態になる。

- 挙動固定・意図固定を defense-in-depth の思想で貫いてきた本リポジトリの他の設定（`DISABLE_UPDATES`、`respondToBashCommands = false`、`worktree.baseRef = "head"` 等）と同じく、サイレントな挙動変化を明示固定で塞ぐ必要がある
- サブエージェント並列度が実際に高い運用のため実害が出やすい
- 修正範囲は `matcher` 1 行と型定義 2 行に閉じるため、コスト対効果が高い

上記より高優先度と判断した。他の中・低は現状の運用と齟齬がなく、defense-in-depth の観点でも上乗せする実効価値が薄いため反映しない。

---
_Generated by [Claude Code](https://claude.ai/code/session_018XGYsyaym5q2spjrk5hPyC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 通知対象を必要なイベントに限定し、並列エージェント完了時の過剰な通知を抑制しました。
  * 入力待ち状態など、新たなエージェント関連イベントの通知に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->