### PR TITLE
feat(claude): CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH を明示固定

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -45,6 +45,18 @@ let
       # 1h 書き込みは 5m の 2x コストだが、TTL 内に 2 回再ヒットすれば元が取れる前提で、
       # ユーザーが確認・思考する数分〜数十分のポーズを跨いでもキャッシュが生きる方が正味でメリットが大きい。
       ENABLE_PROMPT_CACHING_1H = "1";
+      # v2.1.217 で追加。サブエージェントがネストして更にサブエージェントを起動できる最大深度。
+      # 挙動の変遷:
+      #   - v2.1.216 以前: 事実上ネスト可（明示的な深度制御なし）
+      #   - v2.1.217: デフォルトでネスト無効化。この env var を設定して初めてネスト可
+      #   - v2.1.219: デフォルトが depth 3 に変更（ネスト再度有効化・ただし 3 層上限）
+      # `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` + `CLAUDE_CODE_FORK_SUBAGENT` + xhigh + 1h キャッシュ
+      # の並列前提の構成では、reviewer 起点で verifier をファンアウトする等のネスト運用が実運用に
+      # 直結し、上位層のデフォルト値が silent に切り替わると同じ入力で得られるパイプライン形が
+      # 変わってしまう。`worktree.baseRef = "head"` や `respondToBashCommands = false` と同じく、
+      # 短期間に 2 度切り替わったデフォルトを明示固定して silent な挙動変化を防ぐ defense-in-depth。
+      # 値 "3" は v2.1.219 現行デフォルトに揃える（"1" でネスト無効、"2" で 1 段ネストまで）。
+      CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "3";
       # v2.1.143 で追加。GitHub から plugin を取得する際の clone を SSH ではなく HTTPS に固定する。
       # `enabledPlugins` で `claude-plugins-official` 配下の typescript-lsp / pyright-lsp / gopls-lsp を
       # 有効化しているため plugin 取得経路の信頼性は実害に直結する。SSH は ~/.ssh のキー設定・


### PR DESCRIPTION
## 背景: v2.1.199 〜 v2.1.220 の主なアップデート

現在インストール中の Claude Code は `2.1.220`。前回 dotfiles で追跡した `v2.1.198` からの主な変更点は以下（release note 抜粋）。

### 設定・env に直接関わるもの
- **v2.1.219**: `sandbox.network.strictAllowlist` 追加（サンドボックス配下で許可外ホストをプロンプトなしで拒否）／`DirectoryAdded` フック追加／`workflowSizeGuideline` 追加／**サブエージェントの nested spawn がデフォルト depth 3 に**／Fast Mode が Opus 4.7 対象外化（Opus 5 / 4.8 のみ）／Opus 5 がデフォルト Opus モデルに（1M コンテキスト）
- **v2.1.218**: `workflowSizeGuideline` 助言化／`/code-review` を背景サブエージェント化
- **v2.1.217**: `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` 追加（当初はネスト無効化がデフォルト）／`CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` 追加（デフォルト 20）／emoji shortcode 補完（`emojiCompletionEnabled`）
- **v2.1.216**: `sandbox.filesystem.disabled` 追加
- **v2.1.214**: 単一セグメント `dir/**` allow の nested auto-approve バグ修正／PowerShell 5.1 の権限バイパス修正／`EndConversation` ツール追加／docker のデーモンリダイレクト系フラグにプロンプト追加
- **v2.1.212**: `/fork` / `/subtask` 分離／`CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION`（デフォルト 200）／`CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`（デフォルト 200）／MCP 呼び出しの 2 分超で自動 background 化
- **v2.1.210**: `isolation: 'worktree'` の git コマンド誤動作修正
- **v2.1.208**: 画面リーダーモード／`vimInsertModeRemaps`
- **v2.1.207**: Auto mode が Bedrock / Vertex / Foundry で標準有効化／`disableAutoMode` 追加／plugin hook の shell-form での `${user_config.*}` 注入拒否
- **v2.1.206**: `EnterWorktree` が `.claude/worktrees/` 外で確認を要求
- **v2.1.202**: Dynamic workflow size in `/config`
- **v2.1.200**: `permissions.defaultMode = "default"` → `"manual"` 表記変更／`AskUserQuestion` の auto-continue が opt-in に
- **v2.1.199**: slash skills のスタック起動（最大 5）／SSL 証明書エラーの即時失敗化

## 優先度の判断

| 優先度 | 項目 | 判断理由 |
|--------|------|----------|
| **高** | `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "3"` | 本 dotfiles は `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` + `CLAUDE_CODE_FORK_SUBAGENT` + `effortLevel = "xhigh"` + `ENABLE_PROMPT_CACHING_1H` を組んだマルチエージェント前提構成。**v2.1.217 でネスト無効化がデフォルトに、v2.1.219 で depth 3 に**と短期間で 2 度切り替わったサブエージェントネスト深度は、reviewer→verifier ファンアウトのようなパイプライン形状に silent に影響する。`worktree.baseRef = "head"` や `respondToBashCommands = false` と同じく defense-in-depth で明示固定する。 |
| 中 | `sandbox.network.strictAllowlist`（v2.1.219） | セキュリティ強化として設計思想には合致するが、`sandbox.enabled = true` を含めたサンドボックス全体の設計が必要で、`allowedDomains` の運用設計・開発フロー影響が大きい。単独 PR ではなく別途扱う。 |
| 中 | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS`（v2.1.217, default 20） | デフォルト 20 は現行構成で問題なく、既に安定。今すぐの明示ピンは不要。 |
| 中 | Opus 5 デフォルト昇格・Fast Mode の対象モデル変更 | モデル選択自体は個別判断領域で、dotfiles ではモデル明示指定していない。`CLAUDE_CODE_DISABLE_FAST_MODE` の意図（誤起動時の高コスト事故防止）は Opus 5 / 4.8 でも有効なので手当ては不要。 |
| 低 | emoji 補完 / 画面リーダー / vim remap / `disableAutoMode` / `DirectoryAdded` / `EndConversation` / `/fork` `/subtask` 分離 / MCP 自動 background / `/verify` 手動化 等 | 現構成の意図に影響なし、または新機能を選択的に使うだけ。 |

## 変更内容

`home-manager/programs/claude/default.nix` の `env` に以下を追加。

```nix
CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "3";
```

値 `"3"` は v2.1.219 現行デフォルトに揃える（`"1"` でネスト完全無効、`"2"` で 1 段ネストまで）。挙動の変遷とピン留めの意図はコード上のコメントに詳細を残した。

## 見送り理由の補足

release note の変更点は多いが、本 dotfiles のように「デフォルトのサイレント変化を防ぐことに価値を置く」構成では、**「デフォルトが直近で変わった／今後も変わり得る、かつ現構成の意図に直結する」**設定のみを高優先度と判定した。他の項目は新機能を使うかどうかの選択で、使わない限り現状の意図とは競合しない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRgm1mGkQetiP6SLqzPGRA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定**
  * サブエージェントの最大ネスト深度を3に固定しました。
  * バージョン変更によるデフォルト動作の変化を防ぎ、並列処理時の挙動を安定させます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->