### PR TITLE
feat(claude): v2.1.219 の CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH を明示ピン

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -30,6 +30,15 @@ let
       # CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1" と組み合わせた際に真の並列実行となり、
       # 複数エージェント同時起動時のレイテンシとオーバーヘッドを削減する。
       CLAUDE_CODE_FORK_SUBAGENT = "1";
+      # v2.1.219 で「デフォルトを 1 → 3 に変更」とアナウンスされた、ネストサブエージェントの
+      # 最大深さ。CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS + FORK_SUBAGENT を前提にした運用では
+      # Workflow の pipeline / parallel の各ステージから更に agent() を呼ぶ、adversarial
+      # verify を N 並列で回す等の入れ子が日常的に発生し、depth 3 が実効的な下限となる。
+      # 直前バージョンのデフォルトは 1 であり、単発の default 変更で並列ワークフローが
+      # サイレントに degradation する挙動が実証されている。`worktree.baseRef = "head"` や
+      # `respondToBashCommands = false` と同じ「デフォルトのサイレント変化を明示ピンで塞ぐ」
+      # defense-in-depth。現行デフォルトと同値だが、AGENT_TEAMS 系運用の必要下限として固定する。
+      CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "3";
       # v2.1.83 で追加。Bash / hooks / MCP stdio サーバーのサブプロセス env から
       # Anthropic・クラウドプロバイダーのクレデンシャルを剥奪する。deny ルールで
       # 守っている .env / ~/.ssh / ~/.aws / secrets.jsonnet と同じ防御思想の defense-in-depth。


### PR DESCRIPTION
## 概要

Claude Code v2.1.199 〜 v2.1.220 のリリースノートを精査し、AGENT_TEAMS + FORK_SUBAGENT を前提とした本 dotfiles の運用に直接影響する高優先度アップデートを取り込む。

env に `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "3"` を追加する（現行デフォルトと同値だが、AGENT_TEAMS 系運用の必要下限として明示固定）。

## リリースノート精査結果と優先度

v2.1.199 → v2.1.220 のうち本 dotfiles と接点のあるアップデート。優先度は「本 dotfiles の運用にどれだけ直接効くか」「default 変化で既存構成がサイレントに壊れる余地があるか」で判定する。

| 変更 | 導入 | 優先度 | 判断 |
| --- | --- | --- | --- |
| ネストサブエージェント最大深さのデフォルトが `1 → 3` へ変更（`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH`） | v2.1.219 | **高** | 本 PR の対象。詳細は下記。 |
| Claude Opus 5 が default Opus モデルに（1M コンテキスト） | v2.1.219 | 中 | dotfiles は Opus 4.7 前提でチューニング（`effortLevel = "xhigh"` 等）しているが、`model` を settings.json でピンしていないため fresh session では Opus 5 が選ばれ得る。Opus 5 へ移行するのか Opus 4.7 に留めるのかは利用者判断で、effort・prompt caching も併せて再チューニングが必要。単独 PR での対処は避ける。 |
| `sandbox.network.strictAllowlist` / `sandbox.filesystem.disabled` の追加 | v2.1.216, v2.1.219 | 低 | 本 dotfiles は `permissions.deny` + `autoMode.hard_deny` + `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` の三層で defense-in-depth を構築済み。sandbox 系は別軸のオプトインで既存構成の代替ではない。 |
| `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS`（default 20）等の追加 | v2.1.212, v2.1.217 | 低 | デフォルト値が実運用の上限を大きく上回っており、default 変化しても運用は影響を受けない。 |
| `DirectoryAdded` フックの追加 | v2.1.219 | 低 | 現状 `/add-dir` に紐付けたい処理がない。 |
| `workflowSizeGuideline`（default: medium） | v2.1.219 | 低 | 15 agents 制限を実運用で下回るケースは現状ない。 |
| `vimInsertModeRemaps` / `axScreenReader` | v2.1.208 | 低 | vim mode / screen reader を使う運用がない。 |
| `/verify` / `/code-review` の自動起動廃止 | v2.1.215 | 低 | 動作変更のみで設定不要。 |
| `AskUserQuestion` の auto-continue 廃止 | v2.1.200 | 低 | 動作変更のみで設定不要。 |

## 「高」と判断した根拠

`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` を明示ピンする理由:

- ネストサブエージェント深さは、本 dotfiles で明示的に有効化している `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` + `CLAUDE_CODE_FORK_SUBAGENT` の並列実行前提を直接支える。Workflow の pipeline / parallel の各ステージから更に agent() を呼ぶ、adversarial verify を N 並列で回すといった入れ子が実運用で日常的に発生する。
- 直前バージョンでは default が 1 で、v2.1.219 の単発の default 変更で「1 → 3」に振れた実績がある。default 依存のまま放置すると、次に「3 → 1」へ振れた瞬間に AGENT_TEAMS 系ワークフローがサイレントに degradation する。
- 既存の `worktree.baseRef = "head"` / `respondToBashCommands = false` と同じ思想（default 変化で既に有効化済みの機能が壊れないよう明示ピンで塞ぐ defense-in-depth）で一貫する。
- 現行デフォルトと同値の 3 を固定するため、v2.1.219 現在では動作差分なし。回帰時のみ効く保険。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmeYDovWjtMffpejddG7WC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ネストされたサブエージェントの最大起動深度を3階層に制限しました。
  * サブエージェントの過剰な再帰起動を防ぎ、動作を安定化します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->