### PR TITLE
feat(claude): v2.1.199-v2.1.226 のリリースを精査し SUBAGENT_SPAWN_DEPTH を旧デフォルトで固定

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -30,6 +30,17 @@ let
       # CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1" と組み合わせた際に真の並列実行となり、
       # 複数エージェント同時起動時のレイテンシとオーバーヘッドを削減する。
       CLAUDE_CODE_FORK_SUBAGENT = "1";
+      # v2.1.219 でネストサブエージェントのデフォルト depth が 1 → 3 に引き上げられた
+      # （リリースノート: "Subagents can now spawn nested subagents up to depth 3 by default
+      # (was 1); set CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1 to disable nesting"）。
+      # AGENT_TEAMS / FORK_SUBAGENT は「main が並列に多数のサブエージェントを起こす」
+      # 水平方向の並列性を狙って有効化しており、サブエージェントが更にサブエージェントを
+      # 起こす垂直方向のネストは想定していない。depth = 3 だと Opus 4.7 + xhigh + 1h キャッシュの
+      # 重い構成でネスト分の推論コスト・レイテンシが不透明に積み上がる。
+      # respondToBashCommands / worktree.baseRef と同じく、サイレントな挙動変化を避けるため
+      # 旧デフォルト（ネスト無効 = depth 1）を明示固定する。並列サブエージェント自体は
+      # depth 1 でも引き続き機能する（siblings として起動されるため）。
+      CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "1";
       # v2.1.83 で追加。Bash / hooks / MCP stdio サーバーのサブプロセス env から
       # Anthropic・クラウドプロバイダーのクレデンシャルを剥奪する。deny ルールで
       # 守っている .env / ~/.ssh / ~/.aws / secrets.jsonnet と同じ防御思想の defense-in-depth。


### PR DESCRIPTION
## 精査対象

Claude Code v2.1.199 〜 v2.1.226（現在最新）のリリースノートを一通り確認し、`home-manager/programs/claude/default.nix` の現行設定と突き合わせた。

## アップデート内容の要約と優先度判定

### 高（対応する）

**v2.1.219 — サブエージェントのネスト深度デフォルト変更**

リリースノート原文:
> Subagents can now spawn nested subagents up to depth 3 by default (was 1); set `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1` to disable nesting

現行設定は `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` + `CLAUDE_CODE_FORK_SUBAGENT=1` で、main が並列にサブエージェントを起こす**水平方向の並列性**を狙って有効化している。サブエージェントが更にサブエージェントを起こす**垂直方向のネスト**は元々想定しておらず、depth 1 の前提で組んでいた。

v2.1.219 でデフォルトが 3 に上がったことで、Opus 4.7 + `effortLevel = "xhigh"` + 1h prompt caching の重い構成では、ネスト分の推論コスト・レイテンシが不透明に積み上がる。既存の `respondToBashCommands` (v2.1.186)・`worktree.baseRef` (v2.1.143) と同じ「サイレントな挙動変化を旧デフォルトで明示固定する」パターンで対処するのが自然。

→ `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "1"` を追加。

### 中（今回は見送り。判断は保留）

- **v2.1.223 `CLAUDE_CODE_DISABLE_1M_CONTEXT`** — v2.1.219 で Opus 5 (1M context) が default Opus となった。この env を `1` にすると 200K に抑えられる。cost impact は大きい一方、1M context を活かすかは運用ポリシーの選択なので固定は保留。
- **v2.1.219 `workflowSizeGuideline`** — dynamic workflow のサイズガイド。デフォルト `medium` で不都合はなく明示固定の必要性は低い。
- **v2.1.224 `crossSessionInbound` / `dialogExpiry`** — cross-session SendMessage 導入に伴う挙動制御。単一マシン運用では影響が小さい。
- **v2.1.222 worktree isolation の適用範囲拡大** — バイナリ側の修正で完結しており設定変更は不要。

### 低（対応しない）

- v2.1.217 emoji autocomplete / `FORCE_HYPERLINK`
- v2.1.210 screen reader (`axScreenReader`) 系
- v2.1.216 `CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH`
- v2.1.214 `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` / `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` (デフォルト 200 で運用上問題なし)
- v2.1.221 Focus view (VSCode) / `mode: "mask"` (Linux/WSL のみ、macOS では `deny` に fallback)
- v2.1.207 `disableAutoMode` (Bedrock/Vertex/Foundry 限定、非該当)

## 変更点

`home-manager/programs/claude/default.nix` の `env` に `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "1"` を追加。既存の env 群と同じスタイルで、変更根拠（バージョン・原文引用・水平/垂直ネストの整理・pin ポリシーの一貫性）をコメントで明示。

---
_Generated by [Claude Code](https://claude.ai/code/session_017uYwEVAxwA9BBdmpiAPnGh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定**
  * Claude Codeのネストしたサブエージェントの既定最大深度を1に固定しました。
  * サブエージェントの過度な入れ子実行を防止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->