### PR TITLE
feat(claude): CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH を明示固定

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -52,6 +52,16 @@ let
       # `DISABLE_UPDATES = "1"` で更新経路の真実の所在を Homebrew / GitHub Releases に固定したのと同じく、
       # plugin 取得経路も環境差の少ない HTTPS に固定し、運用の予測可能性を高める defense-in-depth。
       CLAUDE_CODE_PLUGIN_PREFER_HTTPS = "1";
+      # v2.1.216 で追加。サブエージェントが nested subagent を spawn できる深さの上限。
+      # v2.1.216 で「nested spawn を default 無効（depth 1）」に変更され、v2.1.219 で
+      # 「default depth 3」に戻された経緯があり、default 挙動が silent に振れた実績がある。
+      # CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS + CLAUDE_CODE_FORK_SUBAGENT で並列サブエージェント
+      # を主戦力にしている現構成では、nested spawn の depth が突然 1 に戻ると agent 設計
+      # （親 agent が子 agent を fan-out し、子がさらに孫を fork するパターン）が壊れて
+      # 沈黙する。`DISABLE_UPDATES = "1"` は claude update 経路を塞ぐが Homebrew 経由の
+      # 昇格は走るため、`worktree.baseRef = "head"` や `respondToBashCommands = false` と
+      # 同じ思想で、現時点の default 値 3 を明示固定して silent な挙動変化を塞ぐ。
+      CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "3";
     };
     # `includeCoAuthoredBy` は deprecated。attribution 設定で commit / pr 双方の帰属表示を空文字列化して抑止する。
     # v2.1.183 で追加された `sessionUrl` は web / Remote Control セッションからの commit / PR に


### PR DESCRIPTION
## アップデート内容の把握

現状の設定は Claude Code v2.1.198 までの変更を反映済み。v2.1.199 以降で dotfiles に関連しうるものを CHANGELOG から拾って整理した。

### v2.1.199 以降で dotfiles に関連しうる変更

| バージョン | 変更 | 現状設定との関係 |
|---|---|---|
| v2.1.200 | `permissions.defaultMode` の `"default"` を `"Manual"` にリネーム、`AskUserQuestion` の自動継続を廃止 | 現在は `defaultMode = "auto"` 明示指定。`"auto"` は独立モードで影響なし |
| v2.1.216 | subagents の nested spawn を default 無効化（depth 1）。`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` 初出。並行実行数上限 `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default 20) 追加 | AGENT_TEAMS + FORK_SUBAGENT 構成では nested spawn 無効化は破壊的 |
| v2.1.217 | `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` (default 200)、`CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` (default 200) 追加 | 通常運用では default で足りるが silent 変化のリスクあり |
| v2.1.219 | Opus 5 リリース・default Opus。Opus 4.7 を fast mode から削除。`MAX_SUBAGENT_SPAWN_DEPTH` の default を 1 → 3 に戻した | Opus 4.7 では `/fast` が最初から効かないため、`CLAUDE_CODE_DISABLE_FAST_MODE = "1"` は Opus 5/4.8 に切替えたときの事故防止として引き続き有効 |
| v2.1.222 | worktree-isolated セッションの destructive git コマンド制限強化 | セキュリティ改善（既存挙動を壊さない） |
| v2.1.224 | `crossSessionInbound` / `dialogExpiry` / sandbox 認証情報マスキング追加 | 現状の運用では未使用 |
| v2.1.232 | Subagent forking が default 有効。`@` メンションで他セッションへ送信 | `CLAUDE_CODE_FORK_SUBAGENT = "1"` は redundant になったが defense-in-depth として維持 |
| v2.1.233 | `CLAUDE_CODE_TOOL_MEMORY_LIMIT` (Linux)、`CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` 追加 | Linux 用 memory limit は macOS 設定に無関係 |

## 優先度判断

### 高

**`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "3"` の明示固定**（本 PR）

- v2.1.216 で default が 1 に変わり、v2.1.219 で 3 に戻された経緯があり、default が silent に振れた実績がある
- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` + `CLAUDE_CODE_FORK_SUBAGENT` で並列サブエージェントを主戦力にする現構成では、depth 1 に戻ると親→子→孫の fork チェーンが沈黙的に壊れる
- `DISABLE_UPDATES = "1"` で `claude update` は塞いでいるが Homebrew 経由の昇格は走るため、`worktree.baseRef = "head"` や `respondToBashCommands = false` と同じ「silent な default 変化を明示固定で塞ぐ」思想に沿う

### 中

- v2.1.217 の `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` / `MAX_WEB_SEARCHES_PER_SESSION`、v2.1.216 の `MAX_CONCURRENT_SUBAGENTS` の明示固定。default 値の変化リスクはあるが、現状のワークロードで default (200 / 200 / 20) が問題を起こしていないため、実害が観測されるまでは default 追従
- v2.1.232 の Subagent forking default 化に伴う `CLAUDE_CODE_FORK_SUBAGENT` コメント更新。設定は変えず、defense-in-depth の理由付けをコメントに追記する程度なので、次回の設定編集タイミングでまとめて対応
- v2.1.219 の Opus 5 リリースに伴う `CLAUDE_CODE_DISABLE_FAST_MODE` の料金体系コメント更新（$30/$150 は Opus 4 系の Fast Mode 料金。Opus 5 は $10/$50）

### 低

- v2.1.233 の `CLAUDE_CODE_TOOL_MEMORY_LIMIT` — Linux 用 cgroup。macOS 設定には無関係
- v2.1.224 の `crossSessionInbound` / `dialogExpiry` / sandbox 認証情報マスキング — 現状運用で未使用
- v2.1.221 の focus view / VSCode `remoteControlAtStartup` — VSCode を使う運用でないため対象外
- v2.1.217 の `emojiCompletionEnabled` — 絵文字補完はガイドライン上使わない

## なぜ「高」としたか

「silent な default 変化を明示固定で塞ぐ」は現行 dotfiles の一貫した設計思想で、以下と同じ位置付け：

- `respondToBashCommands = false`（v2.1.186 で default 反転）
- `worktree.baseRef = "head"`（v2.1.143 で default が head → fresh）
- Notification matcher の `agent_completed` 除外（v2.1.198 で 種別追加）
- `DISABLE_UPDATES = "1"` / `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = "1"` / `CLAUDE_CODE_PLUGIN_PREFER_HTTPS = "1"`

`MAX_SUBAGENT_SPAWN_DEPTH` は「一度 default が反転して再度戻された」実績がある唯一の項目で、他の中優先度項目より silent 変化のリスク実績が高い。並列サブエージェントを主戦力にする構成では nested spawn depth が壊れると agent 設計そのものが機能停止するため、影響範囲が広い点も高判定の根拠。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUiGJvotgUHdmxPzmJPxgw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Claude Codeでネストしたサブエージェントの起動深度を最大3階層に制限しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->